### PR TITLE
Fix KaTeX script in production environment

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -84,6 +84,12 @@ home = ["HTML", "RSS", "REDIR"]
     permalinkable = false
     name = "xml"
 
+[minify]
+  [minify.tdewolff.js]
+    keepVarNames = true
+    precision = 0
+    version = 2022
+
 [module]
   [module.hugoVersion]
     extended = true

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -74,6 +74,12 @@ home = ["HTML", "RSS", "REDIR"]
     permalinkable = false
     name = "xml"
 
+[minify]
+  [minify.tdewolff.js]
+    keepVarNames = true
+    precision = 0
+    version = 2022
+
 [module]
   replacements = 'github.com/gethinode/hinode -> ../..'
   [[module.imports]]

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -17,6 +17,8 @@
     optional = ["leaflet", "katex", "lottie"]
     excludeSCSS = ["bootstrap"]
     disableTemplate = ["katex"]
+    [modules.katex]
+        state = "defer"
     [modules.fontawesome]
         inline = true
         debug = true


### PR DESCRIPTION
Adjust js minification settings to keep variable names. The built in minifier causes a reference error to an undefined variable name.