### PR TITLE
Add fetch priority support for images

### DIFF
--- a/layouts/partials/assets/carousel-item.html
+++ b/layouts/partials/assets/carousel-item.html
@@ -13,7 +13,7 @@
     {{ end -}}
 {{- end -}}
 
-<div class="carousel-item{{ if $active }} active{{ end }}">
+<div class="carousel-item{{ if $active }} active{{ end }}" {{ if not $active }} fetchpriority="low"{{ end }}>
     {{ partial "assets/image.html" (dict "url" $src "ratio" $ratio "page" $page "innerClass" "d-block w-100" "portrait" $portrait "loading" $loading) }}
     <div class="carousel-caption gradient"></div>
     {{ with $caption }}

--- a/layouts/partials/assets/image.html
+++ b/layouts/partials/assets/image.html
@@ -25,6 +25,10 @@
                     loaded images is deferred until the image is within scrolling range of the viewport. This should
                     reduce the initial loading time of the website. It is recommended to lazily load only those images
                     that are below the page fold.
+    "priority":     Optional fetch priority of the image, either "high", "low", or "auto" (default). The priority
+                    provides a hint to the browser on how it should prioritize the fetch of the image relative to other
+                    images. The implementation is experimental and currently only supported by Chrome, Edge, and Opera.
+                    (https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchpriority#browser_compatibility).
     "outerClass":   Optional class attribute of the outer div element, e.g. "img-wrap".
     "innerClass":   Optional class attribute of the inner img element, e.g. "rounded".
     "title":        Optional alternate text of the image.
@@ -63,6 +67,15 @@
     {{ end -}}
 {{- end -}}
 {{- $lazy := eq $loading "lazy" -}}
+
+{{- $priority := .priority -}}
+{{- $validPriorities := slice "high" "low" "auto" -}}
+{{- if $priority -}}
+    {{ if not (in $validPriorities $priority) -}}
+        {{- errorf "partial [assets/image.html] - Invalid value for param 'priority'" -}}
+    {{ end -}}
+{{- end -}}
+{{- if eq $priority "auto" }}{{ $priority = "" }}{{ end -}}
 
 {{- define "partials/image-portrait.html" -}}
     {{- $dimensions := slice }}
@@ -196,6 +209,7 @@
     {{- $modes := .modes -}}
     {{- $lazy := .lazy -}}
     {{- $page := .page -}}
+    {{- $priority := .priority -}}
     {{- $isVector := false -}}
 
     {{- $segments := split $url "#" -}}
@@ -255,6 +269,7 @@
             <img class="img-fluid {{ $innerClass }}"
                 src="{{ $fallbackURL }}"
                 {{ if $lazy }}loading="lazy"{{ end }}
+                {{ with $priority }}fetchpriority="{{ . }}"{{ end }}
                 {{ with $imgset -}}srcset="{{ . }}" sizes="100vw"{{- end }}
                 {{ with $height }}height="{{ . }}"{{ end }}
                 {{ with $width }}width="{{ . }}"{{ end }}
@@ -282,6 +297,7 @@
     "title" $title
     "caption" $caption
     "lazy" $lazy
+    "priority" $priority
     "page" $page)
 -}}
 

--- a/layouts/partials/list/featured.html
+++ b/layouts/partials/list/featured.html
@@ -56,7 +56,7 @@
     {{ else }}
         {{- $thumbnail := (or (and (reflect.IsMap $page.Params.Thumbnail) $page.Params.Thumbnail.url) $page.Params.Thumbnail) -}}
         {{- if $thumbnail }}
-            {{ partial "assets/image.html" (dict "url" $thumbnail "ratio" "16x9" "outerClass" $style "innerClass" "rounded" "title" $page.Site.Title) }}
+            {{ partial "assets/image.html" (dict "url" $thumbnail "ratio" "16x9" "outerClass" $style "innerClass" "rounded" "title" $page.Site.Title "priority" "high") }}
         {{ end }}
     {{ end }}
 {{- end -}}

--- a/layouts/partials/single/thumbnail.html
+++ b/layouts/partials/single/thumbnail.html
@@ -35,5 +35,5 @@
 {{- end -}}
 
 {{ if $thumbnail -}}
-    {{- partial "assets/image.html" (dict "url" $thumbnail "ratio" $ratio "outerClass" $class "innerClass" "rounded" "title" $page.Params.title "caption" $credits) -}}
+    {{- partial "assets/image.html" (dict "url" $thumbnail "ratio" $ratio "outerClass" $class "innerClass" "rounded" "title" $page.Params.title "caption" $credits "priority" "high") -}}
 {{ end -}}


### PR DESCRIPTION
The priority provides a hint to the browser on how it should prioritize the fetch of an image relative to other images. The implementation is experimental and currently only supported by Chrome, Edge, and Opera.

Hinode sets a high priority for the thumbnail image. On list pages, this image is included in the featured section. For single pages, the thumbnail is included in the page header. Carousel images that are not active will receive a low fetch priority. All other images are unchanged.

See https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchpriority#browser_compatibility for browser compatibility.