### PR TITLE
Add 'external' param to link shortcut

### DIFF
--- a/data/structures/link.yml
+++ b/data/structures/link.yml
@@ -56,6 +56,12 @@ arguments:
       Flag to indicate if the retrieved title (e.g. no inner text is provided)
       of an internal link should use its original case. If false, the title is
       set to lower case.
+  external:
+    type: bool
+    optional: true
+    default: false
+    comment: >-
+      Flag to indicate if a link that contains baseURL host should be forced as external.
   class:
     type: string
     optional: true

--- a/layouts/partials/assets/link.html
+++ b/layouts/partials/assets/link.html
@@ -18,9 +18,10 @@
 {{- $target := "" -}}
 {{- $rel := "" -}}
 {{- $case := .case | default true }}
+{{- $external := .external | default false }}
 {{- $cue := .cue | default site.Params.main.externalLinks.cue -}}
 {{- $tab := .tab | default site.Params.main.externalLinks.tab -}}
-{{- $isExternal := ne (urls.Parse (absURL $destination)).Host (urls.Parse site.BaseURL).Host -}}
+{{- $isExternal := or (ne (urls.Parse (absURL $destination)).Host (urls.Parse site.BaseURL).Host) $external -}}
 {{- $page := .page -}}
 {{- $anchor := "" -}}
 {{- $text := .text -}}

--- a/layouts/shortcodes/link.html
+++ b/layouts/shortcodes/link.html
@@ -18,6 +18,7 @@
 {{ $url := "" }}
 {{ $class := "" }}
 {{ $case := true }}
+{{ $external := false }}
 {{ $cue := site.Params.main.externalLinks.cue }}
 {{ $tab := site.Params.main.externalLinks.tab }}
 {{ $text := trim .Inner " \r\n" | .Page.RenderString | safeHTML }}
@@ -30,6 +31,7 @@
     {{- $cue = .Get "cue" | default site.Params.main.externalLinks.cue -}}
     {{- $tab = .Get "tab" | default site.Params.main.externalLinks.tab -}}
     {{- $case = .Get "case" | default true -}}
+    {{- $external = .Get "external" | default false -}}
     {{- $class = .Get "class" | default "" -}}
 {{ else }}
     {{ $href = .Get 0 }}
@@ -42,7 +44,11 @@
 {{ end }}
 
 {{- if hasPrefix $href "http" -}}
+    {{- if $external -}}
+        {{ $url = $href }}
+    {{- else -}}
     {{ $url = strings.TrimPrefix (strings.TrimSuffix "/" site.BaseURL) $href }}
+    {{- end -}}
 {{- else if not (strings.Contains $href "/") -}}
     {{ $url = index site.Params.links $href }}
 {{- end -}}
@@ -65,7 +71,12 @@
     {{ end }}
 {{ end }}
 
-{{- $isExternal := ne (urls.Parse (absURL $url)).Host (urls.Parse site.BaseURL).Host -}}
+{{ if and $external (not (hasPrefix $url "http")) }}
+    {{ errorf "External link must start with 'http': %s" .Position -}}
+    {{ $error = true -}}
+{{ end }}
+
+{{- $isExternal := or (ne (urls.Parse (absURL $url)).Host (urls.Parse site.BaseURL).Host) $external -}}
 {{- if not $isExternal -}}
     {{ $ref := partial "utilities/GetPage.html" (dict "url" $url "page" .Page) }}
     {{- if not $ref -}}
@@ -80,5 +91,5 @@
 
 <!-- Main code -->
 {{- if not $error -}}
-    {{ partial "assets/link.html" (dict "destination" $url "text" $text "cue" $cue "tab" $tab "case" $case "class" $class "page" .Page) }}
+    {{ partial "assets/link.html" (dict "destination" $url "text" $text "cue" $cue "tab" $tab "case" $case "external" $external "class" $class "page" .Page) }}
 {{- end -}}


### PR DESCRIPTION
Add 'external' boolean param to link shortcut. Default state is `false`. Setting this param to `true` will force link that begins with 'http' to be external even if the link is has the same domain as baseURL. See discussion #934  