### PR TITLE
Add missing params.opengraph locale for fr_FR, nl_NL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/_vendor
+_vendor/
 public/
 resources/
 node_modules/

--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -41,7 +41,7 @@ reference = "Meer projecten"
 languageName = "Français"
 contentDir = "content/fr"
 weight = 2
-[nl.params.opengraph]
+[fr.params.opengraph]
 locale = "fr_FR"
 [fr.params.head]
 tagline = "Un thème Hugo"

--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -22,6 +22,8 @@ reference = "More Projects"
 languageName = "Nederlands"
 contentDir = "content/nl"
 weight = 2
+[nl.params.opengraph]
+locale = "nl_NL"
 [nl.params.head]
 tagline = "Een Hugo Thema"
 [nl.params.social]
@@ -39,6 +41,8 @@ reference = "Meer projecten"
 languageName = "Français"
 contentDir = "content/fr"
 weight = 2
+[nl.params.opengraph]
+locale = "fr_FR"
 [fr.params.head]
 tagline = "Un thème Hugo"
 [fr.params.social]


### PR DESCRIPTION
Add missing "params.opengraph" > "locale" for fr_FR, nl_NL instead of the default en_US: <meta property="og:locale" content="en_US" /