### PR TITLE
Bump required Hugo version

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -95,7 +95,7 @@ home = ["HTML", "RSS", "REDIR"]
 [module]
   [module.hugoVersion]
     extended = true
-    min = "0.120.0"
+    min = "0.132.0"
     max = ""
   [[module.mounts]]
     source = "archetypes"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gethinode/hinode",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gethinode/hinode",
-      "version": "0.25.6",
+      "version": "0.25.7",
       "license": "MIT",
       "dependencies": {
         "@fullhuman/postcss-purgecss": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gethinode/hinode",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "description": "Hinode is a clean documentation and blog theme for Hugo, an open-source static site generator",
   "keywords": [
     "hugo",

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ homepage = "https://gethinode.com"
 demosite = "https://demo.gethinode.com"
 tags = ["blog", "documentation", "minimal", "modern", "customizable", "search", "bootstrap"]
 features = ["security aware", "fast by default", "seo-ready", "development tools", "bootstrap framework", "netlify-ready", "full text search", "page layouts", "versioned documentation"]
-min_version = "0.120.0"
+min_version = "0.132.0"
 
 [author]
   name = "Mark Dumay"


### PR DESCRIPTION
Hinode v0.25.5 uses the blockquote template and GitHub-style alerts introduced by Hugo v0.132.0