### PR TITLE
Add support for configurable video players

### DIFF
--- a/assets/scss/components/_video.scss
+++ b/assets/scss/components/_video.scss
@@ -1,11 +1,11 @@
-.youtube-embedded {
+.video-embedded {
     position: relative;
     padding-bottom: 56.25%;
     height: 0;
     overflow: hidden;
 }
 
-.youtube-embedded > iframe {
+.video-embedded > iframe {
     position: absolute;
     top: 0;
     left: 0;

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -27,6 +27,15 @@
         host = "imgix"
 # toml-docs-end images
 
+# toml-docs-start videos
+[videos]
+    [videos.vimeo]
+        host = "vimeo"
+    [videos.youtube]
+        host = "youtube"
+# toml-docs-end images
+
+
 # toml-docs-start debugging
 [debugging]
     showJS = false

--- a/config/_default/server.toml
+++ b/config/_default/server.toml
@@ -14,7 +14,7 @@ for = '/**'
         connect-src 'self'
             https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; \
         font-src 'self' https://fonts.gstatic.com; \
-        frame-src 'self' https://www.youtube-nocookie.com https://www.youtube.com; \
+        frame-src 'self' https://player.vimeo.com https://www.youtube-nocookie.com https://www.youtube.com; \
         img-src 'self' data: https://*.imgix.net https://*.imagekit.io https://*.cloudinary.com https://i.vimeocdn.com https://i.ytimg.com https://*.google-analytics.com https://*.googletagmanager.com https://tile.openstreetmap.org; \
         manifest-src 'self'; \
         media-src 'self' \
@@ -29,7 +29,6 @@ for = '/**'
         camera=(), \
         magnetometer=(), \
         gyroscope=(), \
-        fullscreen=(), \
         payment=() \
         """
     cache-control = """\

--- a/data/structures/video.yml
+++ b/data/structures/video.yml
@@ -1,8 +1,29 @@
 comment: >-
-  Embeds a responsive video player for YouTube videos. Only the ID of the video
-  is required. In privacy-enhanced mode, YouTube will not store information
-  about visitors on your website unless the user plays the embedded video.
+  Embeds a responsive video player for for supported video providers.
 arguments:
+  page:
+    type:
+      - '*hugolib.pageState'
+      - '*hugolib.pageForShortcode'
+    optional: false
+    group: partial
+    release: v0.26.5
+    comment: Context of the current page.
+  position:
+    type:
+      - 'text.Position'
+    optional: true
+    group: partial
+    release: v0.26.5
+    comment: Filename and position from which the shortcode was called.
+  host:
+    type: string
+    optional: true
+    default: youtube
+    release: v0.26.5
+    comment: >-
+      Host name of the video provider. It should match one of the registered
+      providers in the site's parameters under `videos`.
   title:
     type: string
     optional: true

--- a/exampleSite/config/_default/server.toml
+++ b/exampleSite/config/_default/server.toml
@@ -14,7 +14,7 @@ for = '/**'
         connect-src 'self'
             https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; \
         font-src 'self' https://fonts.gstatic.com; \
-        frame-src 'self' https://www.youtube-nocookie.com https://www.youtube.com; \
+        frame-src 'self' https://player.vimeo.com https://www.youtube-nocookie.com https://www.youtube.com; \
         img-src 'self' data: https://*.imgix.net https://*.imagekit.io https://*.cloudinary.com https://i.vimeocdn.com https://i.ytimg.com https://*.google-analytics.com https://*.googletagmanager.com https://tile.openstreetmap.org; \
         manifest-src 'self'; \
         media-src 'self' \
@@ -29,7 +29,6 @@ for = '/**'
         camera=(), \
         magnetometer=(), \
         gyroscope=(), \
-        fullscreen=(), \
         payment=() \
         """
     cache-control = """\

--- a/exampleSite/content/en/blog/bootstrap-elements.md
+++ b/exampleSite/content/en/blog/bootstrap-elements.md
@@ -474,6 +474,16 @@ As an example, the following shortcode displays a tooltip for a colored hyperlin
 {{< /example >}}
 <!-- markdownlint-enable MD037 -->
 
+## Vimeo
+
+As an example, the following shortcode displays a Vimeo video.
+
+<!-- markdownlint-disable MD037 -->
+{{< example lang="hugo" >}}
+{{</* vimeo id="55073825" autoplay=true autotitle=true */>}}
+{{< /example >}}
+<!-- markdownlint-enable MD037 -->
+
 ## Youtube
 
 As an example, the following shortcode displays a Hugo quickstart guide.

--- a/exampleSite/hugo_stats.json
+++ b/exampleSite/hugo_stats.json
@@ -473,11 +473,11 @@
       "top-bar",
       "translate-middle",
       "translate-middle-y",
+      "video-embedded",
       "visually-hidden",
       "vr",
       "w-100",
-      "w-50",
-      "youtube-embedded"
+      "w-50"
     ],
     "ids": [
       "TableOfContents",
@@ -609,6 +609,7 @@
       "toast-message-email-4",
       "toc-collapse",
       "tooltip",
+      "vimeo",
       "youtube"
     ]
   }

--- a/layouts/partials/assets/video.html
+++ b/layouts/partials/assets/video.html
@@ -1,0 +1,107 @@
+<!-- 
+    Copyright © 2024 The Hinode Team / Mark Dumay. All rights reserved.
+    Use of this source code is governed by The MIT License (MIT) that can be found in the LICENSE file.
+    Visit gethinode.com/license for more details.
+
+    This source code adapts the original embedded shortcode as maintained by the Hugo repository. It introduces the
+    following modifications:
+     - Isolated the styles to comply with the Content Security Policy
+     - Added validation of shortcode arguments
+     - Added support to retrieve the title from the video metadata
+     - Adjusted autoplay configuration
+     - Modified the layout
+    
+    The original source code is available on:
+    https://github.com/gohugoio/hugo/tpl/tplimpl/embedded/templates/shortcodes/youtube.html
+    https://github.com/gohugoio/hugo/tpl/tplimpl/embedded/templates/shortcodes/vimeo.html
+    Copyright 2022 The Hugo Authors. Licensed under the Apache License, Version 2.0.
+-->
+
+{{ $error := false }}
+
+<!-- Validate arguments -->
+{{ if partial "utilities/IsInvalidArgs.html" (dict "structure" "video" "args" . "group" "partial") }}
+    {{- errorf "partial [assets/video.html] - Invalid arguments" -}}
+    {{ $error = true }}
+{{ end }}
+
+<!-- Initialize arguments -->
+{{- $page := .page -}}
+{{- $position := .position -}}
+{{- $host := .host -}}
+{{- $title := .title -}}
+{{- $class := .class -}}
+{{- $id := .id -}}
+{{- $autoplay := .autoplay -}}
+{{- $autotitle := .autotitle -}}
+{{- $pc := "" -}}
+{{- if eq $host "youtube" }}
+    {{- $pc = $page.Site.Config.Privacy.YouTube -}}
+{{- else if eq $host "vimeo" }}
+    {{- $pc = $page.Site.Config.Privacy.Vimeo -}}
+{{- end -}}
+
+{{ if and (eq $host "youtube") ($pc.Disable) }}
+    {{- errorf "partial [assets/video.html] - YouTube video disabled in site's privacy settings" -}}
+    {{ $error = true }}
+{{ else if and (eq $host "vimeo") ($pc.Disable) }}
+    {{- errorf "partial [assets/video.html] - Vimeo video disabled in site's privacy settings" -}}
+    {{ $error = true }}
+{{ end }}
+
+<!-- Main code -->
+{{ if not $error -}}
+    {{ if eq $host "youtube" }}
+        {{- $host := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
+        {{ $url := printf "https://%s/embed/%s?origin=%s" $host $id $page.Site.BaseURL }}
+        {{ $api := printf "https://www.youtube.com/oembed?format=json&url=%s" (printf "https://www.youtube.com/watch?v=%s" $id) }}
+
+        {{ if $autotitle }}
+            {{ with resources.GetRemote $api }}
+                {{ with .Err }}
+                    {{ errorf "Unable to parse video metadata '%q': %s\n  %s" $api $position . }}
+                {{ else }}
+                    {{ $data := . | transform.Unmarshal }}
+                    {{ with $data.title }}{{ $title = . }}{{ end }}
+                {{ end }}
+            {{ else }}
+                {{ errorf "Unable to get video metadata '%q': %s" $api $position }}
+            {{ end }}
+        {{ end }}
+
+        <div class="video-embedded {{ $class }}">
+            <iframe src="{{ $url }}{{ if $autoplay }}&autoplay=1&mute=1{{ end }}"
+                allowfullscreen title="{{ $title }}" {{ if $autoplay }}allow="autoplay"{{ end }}>
+            </iframe>
+        </div>
+    {{ else if eq $host "vimeo" }}
+        {{ $url := printf "https://player.vimeo.com/video/%s" $id }}
+        {{ $params := "" }}
+        {{ if $autoplay }}{{ $params = print $params "&autoplay=1&muted=1" }}{{ end }}
+        {{ if $pc.EnableDNT }}{{ $params = print $params "&dnt=1" }}{{ end }}
+        {{ $params = strings.TrimPrefix "&" $params }}
+        {{ with $params }}{{ $url = printf "%s?%s" $url . }}{{ end }}
+
+        {{ if $autotitle }}
+            {{- $dnt := cond $pc.EnableDNT 1 0 -}}
+            {{- $source := urls.JoinPath "https://vimeo.com" $id -}}
+            {{- $query := querify "url" $url "dnt" $dnt -}}
+            {{- $api := printf "https://vimeo.com/api/oembed.json?%s" $query -}}
+            {{- with resources.GetRemote $api -}}
+                {{ with .Err }}
+                    {{ errorf "Unable to parse video metadata '%q': %s\n  %s" $api $position . }}
+                {{ else }}
+                    {{ $data := . | transform.Unmarshal }}
+                    {{ with $data.title }}{{ $title = . }}{{ end }}
+                {{ end }}
+            {{- end -}}
+        {{- end -}}
+
+        <div class="video-embedded {{ $class }}">
+            <iframe src="{{ $url | safeHTMLAttr }}" title="{{ $title }}" webkitallowfullscreen mozallowfullscreen allowfullscreen>
+            </iframe>
+        </div>
+    {{ else }}
+        {{ warnf "partial [assets/video.html] - Unsupported video provider: %s" $host }}
+    {{ end }}
+{{ end -}}

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -21,6 +21,7 @@
 {{- $autotitle := false }}
 
 {{- if .IsNamedParams }}
+    {{ with .Get "host" }}{{ $host = . }}{{ end }}
     {{ with .Get "id" }}{{ $id = . }}{{ end }}
     {{ with .Get "class" }}{{ $class = . }}{{ end }}
     {{ with .Get "title" }}{{ $title = . }}{{ end }}

--- a/layouts/shortcodes/vimeo.html
+++ b/layouts/shortcodes/vimeo.html
@@ -13,10 +13,10 @@
 {{ end }}
 
 <!-- Initialize arguments -->
-{{- $host := "youtube" -}}
+{{- $host := "vimeo" -}}
 {{- $id := "" -}}
 {{- $class := "" -}}
-{{- $title := "YouTube Video" }}
+{{- $title := "Vimeo Video" }}
 {{- $autoplay := false }}
 {{- $autotitle := false }}
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,7 +31,7 @@
             connect-src 'self'
                 https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; \
             font-src 'self' https://*.netlify.app https://fonts.gstatic.com; \
-            frame-src 'self' https://www.youtube-nocookie.com https://www.youtube.com \
+            frame-src 'self' https://player.vimeo.com https://www.youtube-nocookie.com https://www.youtube.com \
                 app.netlify.com; \
             img-src 'self' data: https://*.imgix.net https://*.imagekit.io https://*.cloudinary.com https://*.netlify.app https://i.vimeocdn.com https://i.ytimg.com https://*.google-analytics.com https://*.googletagmanager.com https://tile.openstreetmap.org; \
             manifest-src 'self'; \
@@ -47,7 +47,6 @@
             camera=(), \
             magnetometer=(), \
             gyroscope=(), \
-            fullscreen=(), \
             payment=() \
             """
         cache-control = """\


### PR DESCRIPTION
Refactors previous YouTube shortcode into a reusable video partial. The partial includes support for Vimeo. A new shortcode Vimeo is added.

In the future, the code could be refactored to use adapters, similar to the image partial.