### PR TITLE
Change site.IsMultilingual to hugo.IsMultilingual on navbar.html

### DIFF
--- a/layouts/partials/assets/navbar.html
+++ b/layouts/partials/assets/navbar.html
@@ -107,7 +107,7 @@
     {{- $enableVersions = gt (len $list ) 1 -}}
 {{ end }}
 
-{{- $enableLanguage := or $page.IsTranslated site.IsMultiLingual -}}
+{{- $enableLanguage := or $page.IsTranslated hugo.IsMultilingual -}}
 {{- $horizontal := default false site.Params.navigation.horizontal -}}
 
 {{- $logo := .logo | default site.Params.navigation.logo -}}


### PR DESCRIPTION
navbar.html still uses site.IsMultilingual which was deprecated in 0.124.0. Changed to hugo.IsMultilingual