### PR TITLE
Improve handling of Cloudinary image paths

### DIFF
--- a/exampleSite/content/en/blog/image.md
+++ b/exampleSite/content/en/blog/image.md
@@ -14,7 +14,7 @@ As an example, the following shortcode displays an image with rounded corners an
 
 <!-- markdownlint-disable MD037 -->
 {{< example lang="hugo" >}}
-{{</* image src="https://res.cloudinary.com/demo/image/upload/dog.webp"
+{{</* image src="https://res.cloudinary.com/demo/dog.webp"
     ratio="21x9" caption="Cloudinary image" class="rounded" plain=true */>}}
 {{< /example >}}
 <!-- markdownlint-enable MD037 -->

--- a/layouts/partials/assets/adapters/cloudinary.html
+++ b/layouts/partials/assets/adapters/cloudinary.html
@@ -39,13 +39,22 @@
 {{ $element := "" }}
 
 <!-- Split path between upload dir and sub dir -->
-{{ $newdir := partial "utilities/URLJoin.html" (dict "base" (index (split $dir "upload") 0) "path" "upload") }}
-{{ $file = partial "utilities/URLJoin.html" (dict "base" (index (split $dir "upload") 1) "path" $file) }}
-{{ $dir = $newdir }}
+{{ $dir = path.Clean (trim .dir "/") }}
+{{ $api := "image/upload" }}
+
+<!-- Define the account, optional API segment, and directory -->
+{{ $elements := split $dir "/" }}
+{{ $account := index $elements 0 }}
+{{ $operation := "" }}
+{{ if and (in (slice "image" "video") (index $elements 1)) (eq (index $elements 2) "upload") }}
+    {{ $api = delimit (slice | append (index $elements 1) | append (index $elements 2)) "/" }}
+    {{ $dir = delimit (after 3 $elements) "/" }}
+{{ else }}
+    {{ $dir = delimit (after 1 $elements) "/" }}
+{{ end }}
 
 <!-- Generate image URL -->
 {{ if not $error }}
-    {{ $operation := "" }}
     {{ if $format }}
         {{ $operation = printf "%s,h_%d,w_%d" $transform $height $width }}
         {{ $file = printf "%s.%s" (strings.TrimSuffix (path.Ext $file) $file) $format }}
@@ -55,7 +64,7 @@
     {{ with $anchor }}
         {{ $operation = printf "%s,g_%s" $operation . }}
     {{ end }}
-    {{- $element = partial "utilities/URLJoin.html" (dict "elements" (slice "https://" $host $dir $operation $file)) -}}
+    {{- $element = partial "utilities/URLJoin.html" (dict "elements" (slice "https://" $host $account $api $operation $dir $file)) -}}
 {{ end }}
 
 {{ return $element }}


### PR DESCRIPTION
You can reference an image on Cloudinary by using the account name, relative directory, and file name. However, you can reference the same image by optionally adding the API path (e.g. "image/upload", "video/upload") directly after the account name. Hinode now parses both types of paths correctly.