### PR TITLE
Fix JSON-LD schema params mapping

### DIFF
--- a/layouts/partials/head/structured-data.html
+++ b/layouts/partials/head/structured-data.html
@@ -34,7 +34,7 @@
       "name": "{{ .Site.Params.schema.name }}",
       "url": {{ print $baseURL }},
       "sameAs": {{ $alt | uniq | complement (slice "") }},
-      {{ if eq .Site.Params.schemaType "Organization" -}}
+      {{ if eq .Site.Params.schema.type "Organization" -}}
         "logo": {
           "@type": "ImageObject",
           "@id": {{ print $baseURL "#/schema/image/1"}},


### PR DESCRIPTION
I noticed that the JSON-LD metadata was still showing the default image for image/logo after setting the value under `[schema]` in `params.toml`.

The if statement for the logo/image uses `schemaType`. All other references are `.Site.Params.schema.type`. 

After changing to `...schema.type` to match the others, the logo/image is correctly being updated with the value from params.