### PR TITLE
Update minimum required Hugo version

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -116,8 +116,7 @@ home = ["HTML", "RSS", "REDIR", "netlify", "server"]
 [module]
   [module.hugoVersion]
     extended = true
-    min = "0.134.0"
-    max = ""
+    min = "0.136.3"
   [[module.mounts]]
     source = "archetypes"
     target = "archetypes"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gethinode/hinode",
-  "version": "0.27.22",
+  "version": "0.27.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gethinode/hinode",
-      "version": "0.27.22",
+      "version": "0.27.23",
       "license": "MIT",
       "dependencies": {
         "@fullhuman/postcss-purgecss": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gethinode/hinode",
-  "version": "0.27.22",
+  "version": "0.27.23",
   "description": "Hinode is a clean documentation and blog theme for Hugo, an open-source static site generator",
   "keywords": [
     "hugo",


### PR DESCRIPTION
Hinode now depends on [TrimSpace]( https://gohugo.io/functions/strings/trimspace/). Fixes #1347 