### PR TITLE
fix: improve handling of generated content pages

### DIFF
--- a/layouts/_partials/assets/card-group.html
+++ b/layouts/_partials/assets/card-group.html
@@ -84,7 +84,7 @@
         {{- $params := dict -}}
         {{/* regular page */}}
         {{- if and $element.RelPermalink $element.File -}}
-            {{- $params = merge $params (dict "path" $element.File.Path) -}}
+            {{- $params = merge $params (dict "path" $element.Path) -}}
         {{/* headless page */}}
         {{- else -}}
             {{- $thumbnail := "" -}}

--- a/layouts/_partials/assets/live-pages.html
+++ b/layouts/_partials/assets/live-pages.html
@@ -34,7 +34,7 @@
         {{/* Retrieve the relevant context page, either current page or page identified by section */}}
         {{ $sectionPage := $args.page | default page }}
         {{ if $args.section }}
-            {{ $sectionPage = site.GetPage "section" $args.section }}
+            {{ $sectionPage = site.GetPage $args.section }}
             {{ if not $sectionPage }}
                 {{ warnf "Cannot find section: %s" $args.section }}
             {{ end }}


### PR DESCRIPTION
See https://discourse.gohugo.io/t/content-adapters-site-getpage-without-fully-qualified-path-cannot-find-page/50099