### PR TITLE
fix(navbar): close mobile menu on viewport resize

### DIFF
--- a/assets/js/navbar.js
+++ b/assets/js/navbar.js
@@ -182,7 +182,15 @@ if ((navbar !== null) && (window.performance.getEntriesByType)) {
 if (navbar !== null && togglers !== null) {
   // initialize and update the navbar on load, on resize, and on scroll
   document.addEventListener('DOMContentLoaded', () => { fixed && updateNavbar() })
-  document.addEventListener('resize', () => { fixed && updateNavbar() })
+  window.addEventListener('resize', () => {
+    fixed && updateNavbar()
+    for (let i = 0; i < togglers.length; ++i) {
+      const toggler = togglers[i]
+      if (toggler.getAttribute('aria-expanded') === 'true') {
+        toggler.click()
+      }
+    }
+  })
   document.addEventListener('scroll', () => fixed && updateNavbar())
 
   // hook up collapse events


### PR DESCRIPTION
- Fix resize listener being attached to document instead of window (resize events fire on window, so the old listener never triggered)
- Collapse any open navbar toggler when the viewport is resized, ensuring the mobile menu closes when switching screen sizes in Chrome DevTools device simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)