### PR TITLE
feat(i18n): add toggleSecondary translation for sidebar secondary toggle

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -113,6 +113,8 @@
 # Sidebar
 - id: toggleSidebar
   translation: "Menünavigation anzeigen oder ausblenden"
+- id: toggleSecondary
+  translation: "Weitere Elemente anzeigen oder ausblenden"
 
 # Feature
 - id: addedFeature

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -113,6 +113,8 @@
 # Sidebar
 - id: toggleSidebar
   translation: "Toggle sidebar navigation"
+- id: toggleSecondary
+  translation: "Toggle more items"
 
 # Feature
 - id: addedFeature

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -113,6 +113,8 @@
 # Sidebar
 - id: toggleSidebar
   translation: "Afficher/Masquer la barre latérale"
+- id: toggleSecondary
+  translation: "Afficher/Masquer plus d'éléments"
 
 # Feature
 - id: addedFeature

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -113,6 +113,8 @@
 # Sidebar
 - id: toggleSidebar
   translation: "Toon of verberg navigatie"
+- id: toggleSecondary
+  translation: "Toon of verberg meer items"
 
 # Feature
 - id: addedFeature

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -113,6 +113,8 @@
 # Sidebar
 - id: toggleSidebar
   translation: "Przełącz nawigację na pasku bocznym"
+- id: toggleSecondary
+  translation: "Przełącz więcej elementów"
 
 # Feature
 - id: addedFeature

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -115,6 +115,8 @@
 # Sidebar
 - id: toggleSidebar
   translation: "Mostrar/Ocultar barra lateral"
+- id: toggleSecondary
+  translation: "Mostrar/Ocultar mais itens"
 
 # Feature
 - id: addedFeature

--- a/i18n/zh-hans.yaml
+++ b/i18n/zh-hans.yaml
@@ -113,6 +113,8 @@
 # Sidebar
 - id: toggleSidebar
   translation: "切换侧边栏导航"
+- id: toggleSecondary
+  translation: "切换更多项目"
 
 # Feature
 - id: addedFeature

--- a/i18n/zh-hant.yaml
+++ b/i18n/zh-hant.yaml
@@ -113,6 +113,8 @@
 # Sidebar
 - id: toggleSidebar
   translation: "切換側邊欄導航"
+- id: toggleSecondary
+  translation: "切換更多項目"
 
 # Feature
 - id: addedFeature


### PR DESCRIPTION
Adds the missing `toggleSecondary` key to all supported language files (en, de, fr, nl, pl, pt-br, zh-hans, zh-hant), used as the aria-label on the sidebar secondary toggle button.