### PR TITLE
fix(timeline): guard against nil data when section is provided

### DIFF
--- a/data/structures/timeline.yml
+++ b/data/structures/timeline.yml
@@ -8,6 +8,7 @@ arguments:
     group: partial
   data:
     preview: true
+    optional: true
   section:
     release: v2.7.0
     comment: >-

--- a/layouts/_partials/assets/timeline.html
+++ b/layouts/_partials/assets/timeline.html
@@ -26,7 +26,8 @@
 
 {{/* Initialize local arguments */}}
 {{- $page := $args.page -}}
-{{- $data := partial "utilities/GetI18nData.html" (dict "page" $page "data" $args.data) }}
+{{- $data := "" -}}
+{{- with $args.data -}}{{- $data = partial "utilities/GetI18nData.html" (dict "page" $page "data" .) -}}{{- end -}}
 {{- if and (not $data) (not $args.section) -}}
     {{ partial "utilities/LogErr.html" (dict
         "partial" "assets/timeline.html"


### PR DESCRIPTION
When the timeline partial is called with section instead of data, GetI18nData was invoked with a nil argument causing a runtime error. Guard the call with `with` and mark the data argument as optional.