### PR TITLE
fix: include empty subsections in auto-generated sidebar

### DIFF
--- a/layouts/_partials/assets/live-pages.html
+++ b/layouts/_partials/assets/live-pages.html
@@ -89,6 +89,21 @@
                 {{ range $pages }}
                     {{ $lists = $lists | append .Parent | uniq }}
                 {{ end }}
+                {{/* Also include all descendant subsection pages (covers subsections with no regular children) */}}
+                {{- if $args.nested -}}
+                    {{- $walk := slice $sectionPage -}}
+                    {{- range seq 1 1000 -}}
+                        {{- if not $walk -}}{{- break -}}{{- end -}}
+                        {{- $lastIdx := sub (len $walk) 1 -}}
+                        {{- $current := index $walk $lastIdx -}}
+                        {{- $walk = $walk | first $lastIdx -}}
+                        {{- range $current.Sections -}}
+                            {{- $lists = $lists | append . -}}
+                            {{- $walk = $walk | append . -}}
+                        {{- end -}}
+                    {{- end -}}
+                    {{- $lists = $lists | uniq -}}
+                {{- end -}}
                 {{/* Filter list pages if exclude-filtered is set */}}
                 {{ if $args.excludeFiltered }}
                     {{ $lists = where $lists "Params.excludeFromSidebar" "!=" true }}


### PR DESCRIPTION
The live-pages partial only added subsection list pages by walking the .Parent of regular (leaf) pages. Subsections containing only _index.md (no regular descendants) were silently dropped from the hierarchical menu. Now, when nested is true and group-by is section, walk $sectionPage.Sections recursively so every descendant subsection is included, then deduplicate with the existing parent-based entries.