### PR TITLE
fix(navbar): honor logo-mode site param and clean d-none class output

### DIFF
--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -103,8 +103,9 @@ const purgecss = purgeCSSPlugin({
       // Bootstrap responsive tables
       /table-responsive/,  // All table-responsive-* variants and attribute selectors
 
-      // Color mode toggle - d-none-main-* classes plus [data-bs-main-theme="dark"] compound selectors
-      /d-none-main/,
+      // Color mode toggle - d-none-* and d-none-inline-* (logo modes, navbar mode switcher,
+      // [data-bs-main-theme="dark"] compound selectors)
+      /^d-none-/,
 
       // Bootstrap transitions and utilities that get added via JS
       /fade/,

--- a/layouts/_partials/assets/image.html
+++ b/layouts/_partials/assets/image.html
@@ -64,9 +64,11 @@
 
         {{- range $suffix := $modes -}}
             {{- $image := printf "%s-%s%s" $base $suffix $ext -}}
+            {{- $hidden := printf "d-none-%s" (cond (eq $suffix "dark") "light" "dark") -}}
+            {{- $wrapper := cond (eq $args.wrapper nil) $hidden (printf "%s %s" $args.wrapper $hidden) -}}
             {{- $params = merge $params (dict
-                    "src"   $image
-                    "wrapper" (printf "%s d-none-%s" $args.wrapper (cond (eq $suffix "dark") "light" "dark"))
+                    "src"     $image
+                    "wrapper" $wrapper
             ) -}}
             {{- partial "assets/helpers/image-definition.html" $params -}}
         {{- end -}}

--- a/layouts/_partials/assets/navbar.html
+++ b/layouts/_partials/assets/navbar.html
@@ -92,14 +92,10 @@
 
 {{ $logo := "" }}
 {{ $mode := index site.Params.navigation "logo-mode" | default false }}
-{{ if (not (in $args.default "logo-mode")) }}
-    {{ $mode = $args.logoMode }}
-{{ end }}
+{{ with $args.logoMode }}{{ $mode = . }}{{ end }}
 
 {{ $align := index site.Params.navigation "logo-align" | default "center" }}
-{{ if (not (in $args.default "logo-align")) }}
-    {{ $align = $args.logoAlign }}
-{{ end }}
+{{ with $args.logoAlign }}{{ $align = . }}{{ end }}
 
 {{ if not $args.title }}
     {{ with $args.logo | default site.Params.navigation.logo }}


### PR DESCRIPTION
- Replace $args.default-based override with `with` guard in the navbar partial so a falsy `default: false` no longer clobbers the site param fallback for `logo-mode` (and `logo-align` for symmetry)
- Guard against a nil `wrapper` arg in the image partial to avoid rendering `%!s(<nil>)` in the class string when logo-mode is active
- Broaden PurgeCSS safelist from /d-none-main/ to /^d-none-/ so the dynamic `d-none-light` / `d-none-dark` classes emitted by the image partial survive production builds

Closes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)