### PR TITLE
fix(scss): adapt theme-color utilities and card icons to dark mode

### DIFF
--- a/assets/scss/common/_variables-dark.scss
+++ b/assets/scss/common/_variables-dark.scss
@@ -1,7 +1,9 @@
 @if $enable-dark-mode {
     @include color-mode(dark) {
         --bs-primary: #{$primary-text-emphasis-dark};
+        --bs-primary-rgb: #{to-rgb($primary-text-emphasis-dark)};
         --bs-secondary: #{$secondary-text-emphasis-dark};
+        --bs-secondary-rgb: #{to-rgb($secondary-text-emphasis-dark)};
         --bs-primary-dark: #{$primary-bg-subtle-dark};
         --bs-primary-bg-subtle: #{$primary-bg-subtle-dark};
         --bg-primary-subtle: rgba(var(--bs-primary-rgb), var(--bs-link-opacity, 0.1));

--- a/assets/scss/components/_card.scss
+++ b/assets/scss/components/_card.scss
@@ -10,6 +10,7 @@
     --bs-card-inner-border-radius: #{$theme-border-radius};
     --bs-border-radius: #{$theme-border-radius};
     --bs-card-bg: transparent;
+    --bs-card-icon-color: var(--bs-secondary);
 }
 
 .card .card-img-wrap {
@@ -44,7 +45,7 @@
 }
 
 .card-icon {
-    color: $secondary;
+    color: var(--bs-card-icon-color, var(--bs-secondary));
 }
 
 .card-zoom::after .card-img-wrap img {


### PR DESCRIPTION
Bootstrap's color utilities resolve through the RGB-triplet custom properties (e.g. rgba(var(--bs-primary-rgb), ...)), but the dark-mode block redefined only the hex tokens --bs-primary / --bs-secondary, leaving the -rgb companions frozen at their light values. So .text-primary, .bg-primary, .border-primary etc. kept the light-mode color under [data-bs-theme=dark].

- _variables-dark.scss: redefine --bs-primary-rgb / --bs-secondary-rgb next to the hex tokens so the pair stays in sync.
- _card.scss: color .card-icon via a new --bs-card-icon-color hook (default var(--bs-secondary)) instead of the compile-time $secondary literal, so card icons follow the cascade and are themable per card.