### PR TITLE
feat(sidebar): add logo-mode argument for color-mode variants

### DIFF
--- a/data/structures/sidebar.yml
+++ b/data/structures/sidebar.yml
@@ -73,3 +73,11 @@ arguments:
       Address of the brand logomark to render at the top of the sidebar (Mode A
       only). Visible when the sidebar is in icon-only collapsed mode. Falls
       back to `logo` if omitted.
+  logo-mode:
+    type: bool
+    default: false
+    optional: true
+    comment: >-
+      Flag indicating if the brand logo and logomark should support color
+      modes. If set, the sidebar searches for images having a matching
+      color-mode suffix such as `-light` or `-dark`.

--- a/layouts/_partials/assets/sidebar.html
+++ b/layouts/_partials/assets/sidebar.html
@@ -260,6 +260,7 @@
             {{/* Mode A: L1-only — render group headers as plain links, leaves normally */}}
             {{- $logo          := $args.logo -}}
             {{- $logoCollapsed := index $args "logo-collapsed" -}}
+            {{- $logoMode      := $args.logoMode | default false -}}
             {{- $logoHome      := $args.page.Site.Home.RelPermalink | default "/" -}}
             {{- if or $logo $logoCollapsed -}}
             <a class="sidebar-brand text-decoration-none" href="{{ $logoHome }}" aria-label="{{ T "home" }}">
@@ -268,6 +269,7 @@
                         "src"     .
                         "loading" "eager"
                         "title"   site.Title
+                        "mode"    $logoMode
                         "class"   "sidebar-brand-full"
                     ) }}
                 {{- end -}}
@@ -276,6 +278,7 @@
                         "src"     .
                         "loading" "eager"
                         "title"   site.Title
+                        "mode"    $logoMode
                         "class"   "sidebar-brand-mark"
                     ) }}
                 {{- end -}}


### PR DESCRIPTION
Mirror the navbar's `logo-mode` behavior for the sidebar brand. When enabled, the brand logo and logomark opt into Hinode's color-mode switching, resolving `-light`/`-dark` image variants via the image partial.