### PR TITLE
fix(layouts): preserve inline HTML in title-cased body headings

### DIFF
--- a/assets/scss/common/_styles.scss
+++ b/assets/scss/common/_styles.scss
@@ -93,6 +93,17 @@ main:has(section:first-of-type.section-cover), main:has(section:first-of-type.ba
     color: $primary;
 }
 
+// Site-wide heading title-casing. Toggled per-page via the `title-case` class
+// added by `_markup/render-heading.html` when `site.Params.main.titleCase` is
+// true and the page has not set `exact: true`. Using `text-transform:
+// capitalize` (instead of Go's `title` filter on the rendered HTML) preserves
+// inline markup such as `<code>` from markdown backticks, and lets the browser
+// apply locale-aware capitalization based on the `lang` attribute.
+.title-case
+{
+    text-transform: capitalize;
+}
+
 :root {
     --nav-height: 90px;
 }

--- a/layouts/_markup/render-heading.html
+++ b/layouts/_markup/render-heading.html
@@ -1,6 +1,6 @@
 {{ $class := .Attributes.class }}
 {{ $text := chomp .Text }}
-{{ if and site.Params.main.titleCase (not .Page.Params.exact) }}{{ $text = (title ($text | htmlUnescape)) | htmlEscape }}{{ end }}
+{{ $titleCase := and site.Params.main.titleCase (not .Page.Params.exact) }}
 {{- $headingAnchor := partial "utilities/GetThemeIcon.html" (dict "id" "headingAnchor" "default" "fas link") -}}
 
 {{/* Strip Hugo's HAHAHUGOSHORTCODE placeholder from .Anchor — different render passes
@@ -8,13 +8,30 @@
 {{- $anchor := replaceRE `(?i)hahahugoshortcode\d+s\d+hbhb` "-" .Anchor -}}
 {{- $anchor = trim (replaceRE `-+` "-" $anchor) "-" -}}
 
-{{ if and site.Params.navigation.anchor $text }}
-<h{{ .Level }} id="{{ $anchor | safeURL }}" class="heading {{ with $class }}{{ . }}{{ end }}">
+{{ $useAnchor := and site.Params.navigation.anchor $text }}
+
+{{/* Build the class list:
+     - "heading" is added only on the anchor variant — it hooks `.heading:hover .anchor`.
+     - "title-case" is added when site-wide title casing is enabled and the page has
+       not opted out via frontmatter `exact: true`. The capitalization itself is done
+       in CSS (`text-transform: capitalize`), not by the Go `title` filter, because the
+       heading text may contain inline HTML (e.g. <code> from a markdown backtick) that
+       a string-level transform would mangle. CSS also locale-aware-capitalizes based
+       on the `lang` attribute, which is the right behavior for multilingual sites.
+     - `.Attributes.class` preserves any IAL on the heading. */}}
+{{ $classList := slice }}
+{{ if $useAnchor }}{{ $classList = $classList | append "heading" }}{{ end }}
+{{ if $titleCase }}{{ $classList = $classList | append "title-case" }}{{ end }}
+{{ with $class }}{{ $classList = $classList | append . }}{{ end }}
+{{ $classAttr := delimit $classList " " }}
+
+{{ if $useAnchor }}
+<h{{ .Level }} id="{{ $anchor | safeURL }}" class="{{ $classAttr }}">
     {{- $text | safeHTML -}}
     <a href="#{{ $anchor | safeURL }}" aria-labelledby="{{ $anchor | safeURL }}">
         {{- partial "assets/icon.html" (dict "icon" $headingAnchor "class" "anchor") }}
     </a>
 </h{{ .Level }}>
 {{ else }}
-<h{{ .Level }} id="{{ $anchor | safeURL }}" {{ with $class }} class="{{ . }}"{{ end }}>{{ $text | safeHTML }}</h{{ .Level }}>
+<h{{ .Level }} id="{{ $anchor | safeURL }}"{{ with $classAttr }} class="{{ . }}"{{ end }}>{{ $text | safeHTML }}</h{{ .Level }}>
 {{ end }}


### PR DESCRIPTION
`_markup/render-heading.html` ran `(title ($text | htmlUnescape)) | htmlEscape` on the heading text. Markdown-generated inline HTML such as <code>, <strong>, <em>, and <a> entered that pipeline as ordinary text from Go's perspective, so the `title` filter capitalized the first letter inside each tag name (<code> -> <Code>). The subsequent `htmlEscape` turned the mangled markup into entity-encoded text, leaving readers with literal "<Code>_c</Code>" in the rendered page.

Switch to a CSS-driven approach: emit a `title-case` class on the heading element and let the browser apply `text-transform: capitalize`. The underlying HTML stays intact, inline markup keeps working, and capitalization is locale-aware via the `lang` attribute — useful for multilingual sites where different languages prefer different casing conventions. The existing `site.Params.main.titleCase` toggle and the per-page `exact: true` opt-out are preserved.

The class-list building was unified across the two heading branches so the `title-case` and pre-existing `heading` classes (plus any IAL `.Attributes.class`) compose cleanly.

Only `_markup/render-heading.html` carried this bug. Other title-casing sites in the theme (`header.html`, `docs/header.html`, `minimal/header.html`, `tags/list.html`, `_partials/head/seo.html`, `_partials/footer/social.html`, `_partials/page/taxonomy-*.html`) operate on frontmatter `title:` strings which are plain text and unaffected.