### PR TITLE
feat: register searchindex output for mod-flexsearch lazy loading

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -65,7 +65,7 @@ delimiter = ""
 
 # toml-docs-start outputs
 [outputs]
-home = ["HTML", "RSS", "REDIR", "netlify", "server"]
+home = ["HTML", "RSS", "REDIR", "netlify", "server", "searchindex"]
 # toml-docs-end outputs
 
 # toml-docs-start build

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -58,6 +58,12 @@ defaultContentLanguageInSubdir = false
     baseName = "_redirects"
     isPlainText = true
     notAlternative = true
+  [outputFormats.searchindex]
+    mediaType = "application/json"
+    baseName = "flexsearch-index"
+    isPlainText = true
+    notAlternative = true
+    permalinkable = true
 
 [mediaTypes."text/netlify"]
 delimiter = ""


### PR DESCRIPTION
mod-flexsearch's new lazyLoad option emits the search index via a searchindex Hugo output format that must be attached to home outputs at the theme level — the same wiring netlify and server use for mod-csp. Module-level [outputs] config does not merge into consuming sites; this is where the format gets activated.