### PR TITLE
fix(sidebar): unique nested collapse IDs

### DIFF
--- a/layouts/_partials/assets/sidebar.html
+++ b/layouts/_partials/assets/sidebar.html
@@ -136,11 +136,14 @@
         </div>
         <div class="collapse {{ if $collapsed }}show{{ end }}" id="sidebar-collapse-{{ $index }}-{{ $level }}">
             <ul class="btn-toggle-nav list-unstyled fw-normal {{ if eq $level 0}} pb-1 {{ end }}ps-3">
-                {{- range $item := $group.pages -}}
+                {{- range $childIndex, $item := $group.pages -}}
                     {{- if $item.pages -}}
+                        {{/* Compose a unique index path through the recursion so
+                             nested collapse element IDs stay unique across
+                             sibling branches at the same depth. */}}
                         {{ partial "inline/sidebar/group.html" (dict
                             "page"    $page
-                            "index"   $index
+                            "index"   (printf "%v-%v" $index $childIndex)
                             "level"   (add $level 1)
                             "baseURL" $href
                             "group"   $item


### PR DESCRIPTION
## Problem

In the recursive `_partials/inline/sidebar/group.html`, collapse element IDs are `sidebar-collapse-{{ $index }}-{{ $level }}`, but the recursion passes the parent's `$index` **unchanged** to child groups (only `$level` increments). So every group within the same top-level branch at the same depth gets an identical ID. A section with N sibling sub-groups at the same level produces N elements sharing one ID, and toggling one collapses/expands all of them.

This surfaces on any deep, wide auto-generated sidebar tree (e.g. a docs section with many nested groups).

## Fix

Capture the child loop index during recursion and compose a unique index path (`{{ printf "%v-%v" $index $childIndex }}`), so every nested collapse ID is unique across sibling branches.

## Verification

Reproduced with a wide nested section (7 sibling groups at one depth → seven `sidebar-collapse-4-2`). After the fix each is unique (`4-0-2 … 4-6-2`); toggling one group toggles only that group, confirmed via browser interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)