### PR TITLE
fix(assets): guard nil class and icon-style args to prevent %!s(<nil>) in markup

### DIFF
--- a/layouts/_partials/assets/card-icon.html
+++ b/layouts/_partials/assets/card-icon.html
@@ -29,7 +29,7 @@
             {{- partial "assets/icon.html" (dict "icon" "fas circle" "class" "fa-stack-2x" "spacing" false) -}}
             {{- partial "assets/icon.html" (dict "icon" $args.icon "class" "fa-stack-1x fa-inverse" "spacing" false) -}}
         {{ else }}
-            {{- partial "assets/icon.html" (dict "icon" $args.icon "class" (trim (printf "%s fa-fw" $args.iconStyle) " ") "spacing" false) -}}
+            {{- partial "assets/icon.html" (dict "icon" $args.icon "class" (trim (printf "%s fa-fw" (or $args.iconStyle "")) " ") "spacing" false) -}}
         {{ end }}
     </div>
 {{ end }}

--- a/layouts/_partials/assets/table.html
+++ b/layouts/_partials/assets/table.html
@@ -36,7 +36,7 @@
 {{ end }}
 
 {{/* Initialize local variables */}}
-{{ $class := $args.class }}
+{{ $class := or $args.class "" }}
 {{ if or $args.sortable $args.paginate $args.searchable }}{{ $class = trim (printf "%s data-table" $class) " " }}{{ end }}
 
 {{ $attributes := "" }}


### PR DESCRIPTION
## Problem

When a partial's optional `class` (table) or `icon-style` (card-icon) argument is unset, `printf "%s …"` formats the nil interface as the literal string `%!s(<nil>)`, which then leaks into the rendered `class` attribute. For example, a sortable / searchable / paginated table with no explicit class renders:

```html
<table class="table %!s(<nil>) data-table">
```

and `card-icon` invoked without an `icon-style` produces a similarly polluted icon class.

## Root cause

- `layouts/_partials/assets/table.html` — `{{ $class := $args.class }}` is nil when unset, then `printf "%s data-table" $class`.
- `layouts/_partials/assets/card-icon.html` — `printf "%s fa-fw" $args.iconStyle` with an unset `icon-style`.

## Fix

Default both to `""` with a simple `or` guard before formatting, so the composed class stays clean. No behavior change when the arguments are provided.

## Verification

Built the exampleSite: 0 `%!s(<nil>)` occurrences remain, and sortable tables still emit `class="table data-table"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)