### PR TITLE
fix(sidebar): center footer item on page-footer baseline in both states

### DIFF
--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -363,23 +363,37 @@ html.sidebar-pre-collapsed .sidebar-secondary-row {
     margin-top: auto;
 }
 
-// Sidebar footer: bottom-align the row so the always-visible icon's vertical
-// position stays at the same offset from the footer's bottom in both expanded
-// (row layout, link beside the secondary toggle) and collapsed (column-reverse,
-// link below the toggle). Anchoring against the bottom rather than the row
-// center makes the icon line up cleanly with the page footer's copyright line
-// across both states.
+// Sidebar footer line: keep the always-visible item (e.g. "Infusal Status")
+// vertically centred on the same baseline as the page footer's copyright line
+// in BOTH the expanded and collapsed states. The link is shorter than the
+// secondary toggle, so centring (rather than bottom-anchoring) is what lands its
+// icon on the footer baseline. `min-height` holds the row at the toggle's height
+// so that baseline is identical whether or not the toggle shares the line, and
+// `position: relative` is the positioning context the collapsed toggle is lifted
+// into (see below).
 .sidebar-footer .sidebar-secondary-row {
-    align-items: flex-end !important;
+    align-items: center !important;
+    position: relative;
+    min-height: 2rem;
 }
 
-// In collapsed (column) mode `align-items` controls the cross axis (horizontal),
-// so re-center the single icon column horizontally; the bottom-anchored Y
-// position is preserved by `column-reverse` (link as first DOM child sits at the
-// column's flex-start, which is the visual bottom of the reversed column).
+// Collapsed (icon-only) mode: the link is the single in-flow child and stays
+// centred on the footer line, while the secondary toggle is lifted out of flow
+// and stacked directly above it. This keeps the always-visible icon anchored to
+// the page-footer baseline and stops the two stacked icons from inflating the
+// footer band (the toggle overflows up into the empty space above the footer).
 .sidebar-collapsed .sidebar-footer .sidebar-secondary-row,
 html.sidebar-pre-collapsed .sidebar-collapsible .sidebar-footer .sidebar-secondary-row {
+    flex-direction: row;
     align-items: center !important;
+}
+
+.sidebar-collapsed .sidebar-footer .sidebar-secondary-toggle,
+html.sidebar-pre-collapsed .sidebar-collapsible .sidebar-footer .sidebar-secondary-toggle {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 // scss-docs-end sidebar


### PR DESCRIPTION
## Summary

The always-visible item in the sidebar footer (rendered from a group's `always-visible` entry) was bottom-anchored in its row (`align-items: flex-end`). Because the link is shorter than the secondary toggle button, its icon and label landed a few pixels **below** the page footer's baseline in the expanded layout. In collapsed (icon-only) mode the two stacked icons inflated the footer band, so the icon never settled on that baseline.

This centers the footer item on the page-footer baseline in **both** the expanded and collapsed states.

## Changes (`assets/scss/components/_sidebar.scss`)

- `.sidebar-footer .sidebar-secondary-row`: `align-items: flex-end` → `center`, plus `min-height: 2rem` to hold the row at the toggle's height (so the shorter link's icon lands on the baseline regardless of its own height) and `position: relative` as the positioning context for the collapsed toggle.
- Collapsed mode: keep the link as the single in-flow child (centered) and lift the secondary toggle out of flow (`position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%)`), stacked directly above the link — so it no longer shifts the icon or inflates the footer band.

## Verification

Measured against a real compiled build (page-footer copyright line center = **867.5px**):

| | Expanded | Collapsed |
|---|---|---|
| Footer icon center (before) | 872 (≈4.5px low) | 872, band inflated 64→86px |
| Footer icon center (after) | **867.1** | **867.1** |
| Footer band height (after) | 64px | 64px |
| Secondary toggle (collapsed, after) | n/a | stacked above (y 820–852) |

Icons also align horizontally in collapsed mode (both centerX = 29.5 in the 60px collapsed column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
