### PR TITLE
feat(i18n): fix and add missing French translations

### DIFF
--- a/exampleSite/content/fr/team/_content.gotmpl
+++ b/exampleSite/content/fr/team/_content.gotmpl
@@ -1,0 +1,16 @@
+{{- $contacts := partial "utilities/GetI18nData.html" (dict "page" site "data" "contacts") }}
+
+{{ range $contacts  }}
+    {{ $content := dict "mediaType" "text/markdown" "value" .biography }}
+    {{ $page := dict
+        "content"     $content
+        "description" .function
+        "kind"        "page"
+        "type"        "contact"
+        "path"        (.name | anchorize)
+        "slug"        (.name | anchorize)
+        "title"       .name
+        "params"      (merge . (dict "thumbnail" .image))
+    }}
+    {{ $.AddPage $page }}
+{{ end }}

--- a/exampleSite/content/fr/team/_index.fr.md
+++ b/exampleSite/content/fr/team/_index.fr.md
@@ -1,0 +1,18 @@
+---
+_schema: default
+title: Équipe
+date:
+description: Rencontrez notre équipe d'experts.
+content_blocks:
+  - _bookshop_name: team
+    heading:
+      title: Rencontrez notre équipe
+      content: >-
+        Notre équipe est composée d'experts chevronnés dans leur domaine.
+    input:
+      section: team
+    cols: 5
+    header_style: none
+    padding: 0
+    class: card-zoom border-0
+---

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -30,9 +30,9 @@
 - id: more
   translation: "Plus {{ . }}"
 - id: emptyList
-  translation: "Aucun articles trouvé"
+  translation: "Aucun article trouvé"
 - id: emptyTags
-  translation: "Aucun tags trouvé"
+  translation: "Aucun tag trouvé"
 - id: readMore
   translation: "Lire plus"
 
@@ -94,7 +94,7 @@
 - id: home
   translation: "Accueil"
 - id: languageSwitcherLabel
-  translation: "Langage"
+  translation: "Langue"
 - id: close
   translation: "Fermer"
 
@@ -104,7 +104,7 @@
 - id: seeAlso
   translation: "Voir également"
 - id: sectionMenu
-  translation: "Selectionner un topic"
+  translation: "Sélectionner un sujet"
 - id: tocShowMore
   translation: "Afficher {{ . }} plus"
 - id: tocShowLess
@@ -159,10 +159,10 @@
   translation: "Nom"
 - id: type
   translation: "Type"
-- id: required 
+- id: required
   translation: "Requis"
 - id: default
-  translation: "Défaut"
+  translation: "Par défaut"
 - id: comment
   translation: "Commentaire"
 - id: supportedValues


### PR DESCRIPTION
Fix multiple incorrect French translations in `i18n/fr.yaml` and add the team page at `content/fr/team/`.