### PR TITLE
feat(sidebar): add logo-height argument to size the brand logo

### DIFF
--- a/data/structures/sidebar.yml
+++ b/data/structures/sidebar.yml
@@ -81,3 +81,11 @@ arguments:
       Flag indicating if the brand logo and logomark should support color
       modes. If set, the sidebar searches for images having a matching
       color-mode suffix such as `-light` or `-dark`.
+  logo-height:
+    type: int
+    optional: true
+    comment: >-
+      Height in pixels of the brand logo and logomark (Mode A only). The width
+      is derived automatically from the image's aspect ratio, mirroring the
+      navbar's `logo-height` behavior. When omitted, the images are sized via
+      CSS instead.

--- a/layouts/_partials/assets/sidebar.html
+++ b/layouts/_partials/assets/sidebar.html
@@ -264,25 +264,28 @@
             {{- $logo          := $args.logo -}}
             {{- $logoCollapsed := index $args "logo-collapsed" -}}
             {{- $logoMode      := $args.logoMode | default false -}}
+            {{- $logoHeight    := index $args "logo-height" -}}
             {{- $logoHome      := $args.page.Site.Home.RelPermalink | default "/" -}}
             {{- if or $logo $logoCollapsed -}}
             <a class="sidebar-brand text-decoration-none" href="{{ $logoHome }}" aria-label="{{ T "home" }}">
                 {{- with $logo -}}
                     {{ partial "assets/image.html" (dict
-                        "src"     .
-                        "loading" "eager"
-                        "title"   site.Title
-                        "mode"    $logoMode
-                        "class"   "sidebar-brand-full"
+                        "src"          .
+                        "loading"      "eager"
+                        "title"        site.Title
+                        "mode"         $logoMode
+                        "image-height" $logoHeight
+                        "class"        "sidebar-brand-full"
                     ) }}
                 {{- end -}}
                 {{- with $logoCollapsed -}}
                     {{ partial "assets/image.html" (dict
-                        "src"     .
-                        "loading" "eager"
-                        "title"   site.Title
-                        "mode"    $logoMode
-                        "class"   "sidebar-brand-mark"
+                        "src"          .
+                        "loading"      "eager"
+                        "title"        site.Title
+                        "mode"         $logoMode
+                        "image-height" $logoHeight
+                        "class"        "sidebar-brand-mark"
                     ) }}
                 {{- end -}}
             </a>


### PR DESCRIPTION
## Summary

Mode A sidebars (`level-max = 1`) render the brand logo and logomark through `assets/image.html` without an explicit height, so downstream themes must size them in CSS. This adds an optional **`logo-height`** argument (pixels) to the `sidebar` partial, forwarded to the image partial as `image-height`.

With it set, the logo and logomark carry proportional `height`/`width` attributes and derive their width from the aspect ratio — mirroring how the navbar consumes `navigation.logo-height`, so a shell-mode sidebar brand can match the navbar logo without hand-tuned CSS.

## Changes

- `data/structures/sidebar.yml` — register the optional `logo-height` argument.
- `_partials/assets/sidebar.html` — read `logo-height` and pass it as `image-height` to both the full logo and the logomark.

## Backward compatibility

When `logo-height` is omitted the argument is nil, so `image-height` has no effect and the brand images render exactly as before (CSS-driven). Existing sidebars are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
