### PR TITLE
fix(lightbox): load shell and JS as core so fullscreen is reliable

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -309,6 +309,11 @@
     img-src = ["i.vimeocdn.com"]
     script-src = ["player.vimeo.com"]
 
+# Core furniture: the lightbox <dialog> shell (assets/lightbox.html) and its JS
+# both load on every page so any [data-lightbox-trigger] works without per-page
+# module registration. Kept out of the optional set on purpose — a shortcode
+# registering it via AddModule is a render-order-dependent side effect that a
+# head/footer consumer cannot rely on (see assets/lightbox.html).
 [modules.lightbox]
-    integration = "optional"
+    integration = "core"
     state = "defer"

--- a/layouts/_partials/assets/lightbox-trigger.html
+++ b/layouts/_partials/assets/lightbox-trigger.html
@@ -1,15 +1,14 @@
 {{/*
-    Convenience: render a lightbox trigger button for arbitrary content and
-    register the `lightbox` module dependency. Call with:
+    Convenience: render a lightbox trigger button for arbitrary content. The
+    lightbox shell and JS are core theme furniture (always present), so no
+    module registration is needed. Call with:
       {{ partial "assets/lightbox-trigger.html" (dict "page" . "source" "#my-figure") }}
     `source` is a CSS selector for the node to clone into the lightbox.
     Keep it unique: an id selector must not collide with a Hugo heading
     anchor (heading/page slug), or querySelector may match the wrong element.
 */}}
-{{- $page := .page | default page -}}
 {{- $source := .source -}}
 {{- $icon := partial "utilities/GetThemeIcon.html" (dict "id" "lightboxExpand" "default" "fas expand") -}}
-{{- partial "utilities/AddModule.html" (dict "page" $page "module" "lightbox") -}}
 <button type="button" class="control-btn-lightbox" data-lightbox-trigger data-lightbox-source="{{ $source }}"
         aria-label="{{ i18n "lightboxExpand" }}">
     {{- partial "assets/icon.html" (dict "icon" $icon "class" "fa-fw fa-xl" "spacing" false) -}}

--- a/layouts/_partials/assets/lightbox.html
+++ b/layouts/_partials/assets/lightbox.html
@@ -1,19 +1,21 @@
 {{/*
-    Reusable lightbox <dialog> shell. Rendered once per page, only when the
-    `lightbox` module dependency is registered (via utilities/AddModule.html).
-    The lightbox JS module (assets/js/modules/lightbox/lightbox.mjs) clones a
-    trigger's source node into `.lightbox-content` and calls showModal().
+    Reusable lightbox <dialog> shell — core theme furniture, rendered once on
+    every page. The lightbox JS module (assets/js/modules/lightbox/lightbox.mjs,
+    bundled in core) clones a [data-lightbox-trigger] source node into
+    `.lightbox-content` and calls showModal(). The shell is inert until a
+    trigger on the page is clicked.
+
+    Rendered unconditionally on purpose: a shortcode that registers the
+    lightbox dependency (via utilities/AddModule.html) does so as a side effect
+    of content rendering, and per Hugo's own docs a value set that way is
+    "indeterminate until Hugo renders the page content"
+    (https://gohugo.io/methods/page/store/). A parent template that reads it —
+    like this shell — cannot rely on it. Always rendering removes that race.
 */}}
-{{- $deps := page.Scratch.Get "dependencies" -}}
-{{- $enabled := false -}}
-{{- if and (reflect.IsSlice $deps) (in $deps "lightbox") -}}{{- $enabled = true -}}{{- end -}}
-{{- if and (reflect.IsSlice .Params.modules) (in .Params.modules "lightbox") -}}{{- $enabled = true -}}{{- end -}}
-{{- if $enabled -}}
-    {{- $close := partial "utilities/GetThemeIcon.html" (dict "id" "lightboxClose" "default" "fas xmark") -}}
-    <dialog class="lightbox" aria-label="{{ i18n "lightboxLabel" }}">
-        <button type="button" class="lightbox-close" aria-label="{{ i18n "lightboxClose" }}">
-            {{- partial "assets/icon.html" (dict "icon" $close "class" "fa-fw fa-xl" "spacing" false) -}}
-        </button>
-        <div class="lightbox-content"></div>
-    </dialog>
-{{- end -}}
+{{- $close := partial "utilities/GetThemeIcon.html" (dict "id" "lightboxClose" "default" "fas xmark") -}}
+<dialog class="lightbox" aria-label="{{ i18n "lightboxLabel" }}">
+    <button type="button" class="lightbox-close" aria-label="{{ i18n "lightboxClose" }}">
+        {{- partial "assets/icon.html" (dict "icon" $close "class" "fa-fw fa-xl" "spacing" false) -}}
+    </button>
+    <div class="lightbox-content"></div>
+</dialog>


### PR DESCRIPTION
## Summary

The lightbox `<dialog>` shell and its JS rendered unreliably. On a page using a fullscreen/lightbox shortcode the **trigger button rendered but the dialog + JS were frequently absent**, so clicking did nothing — and it varied build to build.

Root cause: the shell (`assets/lightbox.html`) and the optional-scripts pass gated on the `lightbox` module dependency that shortcodes register via `AddModule` → `page.Scratch "dependencies"` **during content rendering**. Per Hugo's own docs a value set that way is ["indeterminate until Hugo renders the page content"](https://gohugo.io/methods/page/store/), so the head/shell consumers that read it too early saw it only intermittently.

Fixes #1981.

## Change

Treat the lightbox as **core theme furniture** rather than an opt-in module:

- render the `<dialog>` shell on every page (inert until a `[data-lightbox-trigger]` is clicked);
- flip the module to `integration = "core"` so its JS always bundles into the core set;
- drop the now-vestigial `AddModule` call from `assets/lightbox-trigger.html`.

Nothing reads the indeterminate `dependencies` channel anymore, so any `[data-lightbox-trigger]` works without per-page `modules:` front matter.

## Verification

Built the exampleSite against this branch and drove the `lightbox-demo` page (front matter is `title` only — the previously-failing config) with Playwright:

- shell present on the demo page **and** on pages with no lightbox usage (always-render);
- `showModal`/lightbox JS present in `core.bundle.*.mjs` (loaded everywhere);
- dialog opens in the top layer (`:modal`) with the source node cloned in and the nested trigger stripped;
- close button + Esc + backdrop-close intact.

## Notes

- `fix:` → patches to v2.16.1.
- Follow-up (not in this PR): the same `dependencies`-scratch indeterminacy is latent for the `<head>` CSS/JS consumers (`head/head.html`, critical/functional passes). They're safe today because modules are conventionally declared in front matter, but a `.Content`-noop or a doc caveat would harden them — see #1981.