### PR TITLE
feat(lightbox): frosted backdrop behind the close button

### DIFF
--- a/assets/scss/common/_styles.scss
+++ b/assets/scss/common/_styles.scss
@@ -15,6 +15,12 @@
 //
 html {
     scrollbar-gutter: stable;
+
+    // Expose the theme border radius as a custom property so components in
+    // module stylesheets — which compile standalone, without theme SCSS
+    // variables in scope — can pick up the theme radius instead of falling
+    // back to Bootstrap's default.
+    --theme-border-radius: #{$theme-border-radius};
 }
 
 //

--- a/assets/scss/components/_lightbox.scss
+++ b/assets/scss/components/_lightbox.scss
@@ -43,8 +43,14 @@ dialog.lightbox {
   padding: 0.25rem 0.5rem;
   line-height: 1;
   color: var(--bs-body-color);
-  background: transparent;
+
+  // Frosted background matching the mermaid diagram controls, so the close
+  // button stays legible when it overlays diagram or image content.
+  background-color: rgba(var(--bs-body-bg-rgb), 0.65);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border: 0;
+  border-radius: #{$theme-border-radius};
   cursor: pointer;
   opacity: 0.7;
 


### PR DESCRIPTION
## Summary

Give the lightbox close button a frosted background (translucent body background + backdrop blur) matching the mermaid diagram controls, so it stays legible when it overlays diagram or image content.

Also expose the theme border radius as a `--theme-border-radius` custom property on `html`, so components in **module** stylesheets — which compile standalone, without theme SCSS variables in scope — can pick up the theme radius instead of Bootstrap's default. This keeps the close button and mod-mermaid's controls visually consistent (both use the theme radius).

## Verification

Built a consuming portal: the close button and the mermaid controls both render a frosted background with the theme's border radius (0 in a squared theme), matching, in both inline and fullscreen modes.
