### PR TITLE
feat(head): optional application version meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ To add mod-blocks to your site:
 
 See the [official documentation][getstarted] on how to configure your site.
 
+### Application version meta tag
+
+Set `[params.application]` to advertise your site's own release version in the document head, alongside the `generator` and `theme` tags:
+
+```toml
+[params.application]
+  name = "My App"
+```
+
+This renders `<meta name="application" content="My App <version>">`. The version resolves from `params.application.version`, else the `HUGO_APPLICATION_VERSION` environment variable (set this in your build / CI pipeline), else the short Git commit hash when `enableGitInfo` is on. Sites that omit `[params.application]` render no such tag.
+
 ## Contributing
 
 See the [official documentation][contribute] on how to contribute to the open-source development of Hinode.

--- a/layouts/_partials/assets/app-version.html
+++ b/layouts/_partials/assets/app-version.html
@@ -1,0 +1,28 @@
+{{/*
+    Copyright © 2022 - 2026 The Hinode Team / Mark Dumay. All rights reserved.
+    Use of this source code is governed by The MIT License (MIT) that can be found in the LICENSE file.
+    Visit gethinode.com/license for more details.
+*/}}
+
+{{/* Resolves the downstream application's own release version for the
+     <meta name="application"> tag. Precedence:
+       1. site.Params.application.version   (explicit config override)
+       2. HUGO_APPLICATION_VERSION env var   (CI / build injection)
+       3. hugo.CommitHash (short)            (local builds with enableGitInfo)
+     Returns an empty string when none resolve. A leading "v" is stripped. */}}
+{{- define "_partials/inline/env-app-version.html" -}}
+    {{- return getenv "HUGO_APPLICATION_VERSION" -}}
+{{- end -}}
+
+{{- $version := "" -}}
+{{- with site.Params.application -}}
+    {{- with .version -}}{{- $version = . -}}{{- end -}}
+{{- end -}}
+{{- if not $version -}}
+    {{- $version = partial "inline/env-app-version.html" . -}}
+{{- end -}}
+{{- if not $version -}}
+    {{- with hugo.CommitHash -}}{{- $version = printf "g%s" (substr . 0 7) -}}{{- end -}}
+{{- end -}}
+{{- $version = $version | default "" | strings.TrimPrefix "v" -}}
+{{- print $version -}}

--- a/layouts/_partials/head/head.html
+++ b/layouts/_partials/head/head.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     {{ hugo.Generator }}
     <meta name="theme" content="{{ printf "Hinode %s" $version }}">
+    {{- if isset site.Params "application" -}}
+        {{- $appVersion := strings.TrimSpace (partialCached "assets/app-version.html" $ "app-version") -}}
+        {{- with $appVersion -}}
+            <meta name="application" content="{{ with site.Params.application.name }}{{ . }} {{ end }}{{ $appVersion }}">
+        {{- end -}}
+    {{- end -}}
     {{ partialCached "head/stylesheet-core.html" . -}}
 
     {{ $config := page.Scratch.Get "modules" }}


### PR DESCRIPTION
## Summary

Adds an opt-in third `<head>` identity meta tag — `<meta name="application" content="<label> <version>">` — alongside the existing `generator` (Hugo) and `theme` (Hinode) tags. A site advertises its own release version by declaring `[params.application]`; sites that omit it render nothing.

## Changes

- New resolver `layouts/_partials/assets/app-version.html` (mirrors `assets/version.html`): resolves the version as `params.application.version` → `HUGO_APPLICATION_VERSION` env → short commit hash (via `enableGitInfo`), stripping a leading `v`.
- `layouts/_partials/head/head.html`: renders the tag when `isset site.Params "application"` — opt-in on block *presence*, so non-adopting sites are unaffected.
- `README.md`: documents the config.

## Verification

Built `exampleSite` across all cases: bare `[application]` + `HUGO_APPLICATION_VERSION=9.9.9` → `content="9.9.9"`; `[application] name="My App"` (no env) → `content="My App g<hash>"`; no block → no tag. Lint clean.

## Motivation

Lets a Hinode-based site advertise its own build/release version in the document head. The version is supplied via config or the `HUGO_APPLICATION_VERSION` environment variable at build/CI time, with a graceful commit-hash fallback for local builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
