### PR TITLE
fix(head): drop misleading commit-hash fallback for application version

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Set `[params.application]` to advertise your site's own release version in the d
   name = "My App"
 ```
 
-This renders `<meta name="application" content="My App <version>">`. The version resolves from `params.application.version`, else the `HUGO_APPLICATION_VERSION` environment variable (set this in your build / CI pipeline), else the short Git commit hash when `enableGitInfo` is on. Sites that omit `[params.application]` render no such tag.
+This renders `<meta name="application" content="My App <version>">`. The version resolves from `params.application.version`, else the `HUGO_APPLICATION_VERSION` environment variable (set this in your build / CI pipeline). Sites that omit `[params.application]`, or that set neither a config value nor the environment variable, render no such tag.
 
 ## Contributing
 

--- a/layouts/_partials/assets/app-version.html
+++ b/layouts/_partials/assets/app-version.html
@@ -8,8 +8,8 @@
      <meta name="application"> tag. Precedence:
        1. site.Params.application.version   (explicit config override)
        2. HUGO_APPLICATION_VERSION env var   (CI / build injection)
-       3. hugo.CommitHash (short)            (local builds with enableGitInfo)
-     Returns an empty string when none resolve. A leading "v" is stripped. */}}
+     Returns an empty string when neither resolves (no tag is rendered).
+     A leading "v" is stripped. */}}
 {{- define "_partials/inline/env-app-version.html" -}}
     {{- return getenv "HUGO_APPLICATION_VERSION" -}}
 {{- end -}}
@@ -20,9 +20,6 @@
 {{- end -}}
 {{- if not $version -}}
     {{- $version = partial "inline/env-app-version.html" . -}}
-{{- end -}}
-{{- if not $version -}}
-    {{- with hugo.CommitHash -}}{{- $version = printf "g%s" (substr . 0 7) -}}{{- end -}}
 {{- end -}}
 {{- $version = $version | default "" | strings.TrimPrefix "v" -}}
 {{- print $version -}}


### PR DESCRIPTION
## Summary

Fixes a misleading fallback in the application-version resolver added in v2.18.0. `hugo.CommitHash` is the **Hugo executable's** build commit (a constant across every site built with the same Hugo binary), not the site's commit — so a site that opted in via `[params.application]` without supplying a version rendered a bogus, constant "version" string.

The resolver now resolves the version from `params.application.version` or the `HUGO_APPLICATION_VERSION` environment variable only, and renders **no** `<meta name="application">` tag when neither is set.

## Verification

Built `exampleSite`: `[params.application]` + `HUGO_APPLICATION_VERSION=9.9.9` → `content="… 9.9.9"`; `[params.application]` with no version and no env var → **no tag** (previously leaked the Hugo binary's commit hash); no block → no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
