### PR TITLE
fix(sidebar): match L2+ group headers to nested leaf font size

### DIFF
--- a/layouts/_partials/assets/sidebar.html
+++ b/layouts/_partials/assets/sidebar.html
@@ -111,7 +111,7 @@
                 {{ if or $current (not $ref) }}
                     {{ $dest = "" }}
                 {{ end }}
-                <a {{ with $dest }} href="{{ . }}"{{ else }}
+                <a {{ if gt $level 1 }}class="small" {{ end }}{{ with $dest }} href="{{ . }}"{{ else }}
                 data-bs-toggle="collapse"
                 data-bs-target="#sidebar-collapse-{{ $index }}-{{ $level }}"
                 {{ end }}>


### PR DESCRIPTION
## Problem

The sidebar mixes font sizes by intent: L1 entries render at the base size (16px) and L2+ entries at the `small` size (14px). But **nested (L2+) group headers render at 16px instead of 14px**, so a collapsible parent looks larger than the leaves around it at the same visual level.

## Root cause

Leaves and group headers are rendered by two different inline partials, and only one applies the `small` class:

- **Leaves** (`inline/sidebar/item.html`) add `small` to the anchor for `level != 0`, so nested leaves are 14px. ✓
- **Group headers** (`inline/sidebar/group.html`) render the title anchor with **no class at all**, so every collapsible parent inherits the 16px base regardless of depth. ✗

## Fix

Add `small` to the group anchor when the group is nested:

```diff
- <a {{ with $dest }} href="{{ . }}"{{ else }}
+ <a {{ if gt $level 1 }}class="small" {{ end }}{{ with $dest }} href="{{ . }}"{{ else }}
```

Groups sit one level deeper than leaves in the recursion (a top-level group is `level 1`, a top-level leaf is `level 0`), so the threshold is `gt $level 1` here versus `ne $level 0` for items. Top-level (L1) group headers are unchanged.

## Verification

Built `exampleSite` against the change. The shipped example content never nests groups two deep, so a temporary 3-level fixture was added to exercise the L2+ group path, then removed:

| Entry | Level | `small`? | Size |
| --- | --- | --- | --- |
| Group parent | L1 (top of nav) | no | 16px ✓ (unchanged) |
| Group parent | **L2, nested** | **yes** | **14px ✓ (fixed)** |
| Leaf | L2+ | yes | 14px ✓ (unchanged) |

A full scan of every rendered page confirmed **240 L1 group headers, none wrongly shrunk** — no regression. The change is CSS-class only (Bootstrap `.small`) and does not affect the group link's color/layout rules or the collapse chevron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
