### PR TITLE
fix(sidebar): stop overlay scrollbar overlapping sidebar items

### DIFF
--- a/assets/scss/app-dart.scss
+++ b/assets/scss/app-dart.scss
@@ -20,6 +20,9 @@
 // Include dark mode overrides
 @import "common/variables-dark.scss";
 
+// Scrollbar mixin — imported before the components so they can @include it
+@import "common/scrollbar.scss";
+
 // Import Hinode theme styles
 @import "components/abbr.scss";
 @import "components/alert.scss";
@@ -51,7 +54,6 @@
 @import "components/lightbox.scss";
 @import "common/animation.scss";
 @import "common/masonry.scss";
-@import "common/scrollbar.scss";
 @import "common/styles.scss";
 @import "layouts/reboot.scss";
 @import "layouts/type.scss";

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -18,6 +18,9 @@
 // Include dark mode overrides
 @import "common/variables-dark.scss";
 
+// Scrollbar mixin — imported before the components so they can @include it
+@import "common/scrollbar.scss";
+
 // Import Hinode theme styles
 @import "components/abbr.scss";
 @import "components/alert.scss";
@@ -49,7 +52,6 @@
 @import "components/lightbox.scss";
 @import "common/animation.scss";
 @import "common/masonry.scss";
-@import "common/scrollbar.scss";
 @import "common/styles.scss";
 @import "layouts/reboot.scss";
 @import "layouts/type.scss";

--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -44,6 +44,20 @@ html.sidebar-pre-collapsed .sidebar-collapsible .sidebar-brand {
     max-height: calc(100vh - var(--navbar-offset));
     overflow-y: auto;
     scrollbar-gutter: stable;
+
+    // `scrollbar-gutter: stable` reserves the gutter only for classic
+    // scrollbars. On macOS, Chrome/Safari default to overlay scrollbars,
+    // which take no layout space — so the gutter collapses to 0 and the bar
+    // floats over the sidebar content (the group chevrons). Styling the
+    // scrollbar opts the element out of overlay mode, giving a non-overlay bar
+    // that reserves width and sits in the stable gutter, consistent across
+    // browsers. A muted thumb on a transparent track keeps it subtle and
+    // light/dark aware.
+    @include scrollbar(
+        $foreground-color: var(--bs-border-color),
+        $background-color: transparent,
+        $size: 8px
+    );
 }
 
 .sidebar-item {


### PR DESCRIPTION
## Problem

The docs sidebar scrolls inside `.sidebar-overflow`, which sets `scrollbar-gutter: stable`. That gutter is only honored for **classic** (non-overlay) scrollbars. On macOS, Chrome/Safari default to **overlay** scrollbars, which take zero layout space — so the reserved gutter collapses to 0 and the vertical scrollbar floats over the sidebar content (the collapsible group chevrons). Chrome fattens the overlay bar while scrolling, making the overlap worse. Windows/Linux (and macOS set to "always show scrollbars") never hit it because those use classic scrollbars where the gutter is honored — hence the cross-browser divergence.

## Fix

Style the sidebar scrollbar so it opts **out** of overlay mode. Defining `::-webkit-scrollbar` makes Blink/WebKit render a non-overlay bar that reserves width and sits in the `scrollbar-gutter: stable` gutter instead of over the content; Firefox gets the same determinism from `scrollbar-color`. The result is one consistent, gutter-parked scrollbar across browsers.

Reuses the existing `scrollbar` mixin (`common/scrollbar.scss`) with a muted thumb on a transparent track, so it stays subtle and light/dark aware:

```scss
.sidebar-overflow {
    scrollbar-gutter: stable;
    @include scrollbar($foreground-color: var(--bs-border-color),
                       $background-color: transparent, $size: 8px);
}
```

That mixin previously lived in `common/scrollbar.scss`, imported **after** the components, so no component could `@include` it. This moves the import ahead of the components block so the shared mixin is available to them (used here by the sidebar; navbar/toc could adopt it later).

## Verification

- Standalone `dart-sass` compile of `common/scrollbar.scss` + the exact `.sidebar-overflow` call emits the expected `::-webkit-scrollbar{-thumb,-track}` rules and the Firefox `@supports scrollbar-color` fallback.
- The Hugo dartsass pipeline compiles the reordered imports with no Sass error (an out-of-scope mixin would fail there), confirming the mixin is now reachable from `_sidebar.scss`.
- The identical treatment was validated visually in a downstream site (Chrome + Safari, light + dark): the bar now parks in its gutter and no longer overlaps the group chevrons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
