### PR TITLE
feat(lightbox): fade the dialog in and out

### DIFF
--- a/assets/scss/components/_lightbox.scss
+++ b/assets/scss/components/_lightbox.scss
@@ -61,19 +61,48 @@ dialog.lightbox {
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  dialog.lightbox[open] {
-    animation: lightbox-in 0.15s ease-out;
+  // Fade + subtle scale on both open and close. `@starting-style` supplies the
+  // pre-open value so the entry transition runs, and `allow-discrete` on
+  // `display`/`overlay` keeps the dialog in the top layer long enough to animate
+  // out before it is hidden. Browsers without these features simply skip the
+  // animation (the dialog appears/disappears instantly) — no worse than a cut.
+  dialog.lightbox {
+    opacity: 0;
+    transform: scale(0.98);
+    transition:
+      opacity 0.2s ease-out,
+      transform 0.2s ease-out,
+      overlay 0.2s ease-out allow-discrete,
+      display 0.2s ease-out allow-discrete;
   }
 
-  @keyframes lightbox-in {
-    from {
+  dialog.lightbox[open] {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  @starting-style {
+    dialog.lightbox[open] {
       opacity: 0;
       transform: scale(0.98);
     }
+  }
 
-    to {
-      opacity: 1;
-      transform: scale(1);
+  dialog.lightbox::backdrop {
+    opacity: 0;
+    transition:
+      opacity 0.2s ease-out,
+      overlay 0.2s ease-out allow-discrete,
+      display 0.2s ease-out allow-discrete;
+  }
+
+  dialog.lightbox[open]::backdrop {
+    opacity: 1;
+  }
+
+  @starting-style {
+    dialog.lightbox[open]::backdrop {
+      opacity: 0;
     }
   }
 }


### PR DESCRIPTION
## What

The reusable lightbox `<dialog>` now fades **in and out** (opacity + subtle scale, plus the backdrop), replacing the fade-in-only keyframe.

## How

Transition-based, using `@starting-style` for the pre-open value and `transition-behavior: allow-discrete` on `display`/`overlay` so the dialog animates out before it leaves the top layer. Still gated behind `prefers-reduced-motion: no-preference`; browsers without `@starting-style`/`allow-discrete` simply skip the animation (instant, no worse than today).

## Why

Opening/closing the lightbox (images and cloned mermaid diagrams) was abrupt on close. This gives a subtle, consistent fade both directions.

## Verification

dart-sass compiles the new `@starting-style`/`allow-discrete` syntax; the full exampleSite build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)