### PR TITLE
test: build without Windows hoisted node-linker step (DO NOT MERGE)

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lint-build:
-    uses: gethinode/.github/.github/workflows/lint-build.yml@v1
+    uses: gethinode/.github/.github/workflows/lint-build.yml@test/no-hoisted
     with:
       package-manager: pnpm
       lint-script: lint


### PR DESCRIPTION
Temporary validation for the @v1 cleanup. Points the lint-build caller at `gethinode/.github@test/no-hoisted` (which removes the Windows `node_linker=hoisted` step from setup-hinode). If the **windows-latest** build legs pass, cmd-shim alone handles Hugo's postcss shim and the hoisted step can be dropped from @v1. Draft — will be closed, not merged.