### PR TITLE
fix(components): drop stale backdrop offset in bookshop examples

### DIFF
--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20260210181720-337dd2045d56 // indirect
 	github.com/cloudcannon/bookshop/hugo/v3 v3.18.5 // indirect
-	github.com/gethinode/mod-blocks v1.23.5 // indirect
+	github.com/gethinode/mod-blocks v1.23.6 // indirect
 	github.com/gethinode/mod-bootstrap-icons v1.4.4 // indirect
 	github.com/gethinode/mod-cookieyes/v2 v2.2.6 // indirect
 	github.com/gethinode/mod-docs v1.14.1 // indirect

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -4,6 +4,8 @@ github.com/cloudcannon/bookshop/hugo/v3 v3.18.5 h1:AKWzUQpWcBSbJgHQ/5cfPQtGX40bn
 github.com/cloudcannon/bookshop/hugo/v3 v3.18.5/go.mod h1:s7mIonDhtsLcn10ZKuVXyqd6BDHI8vT1WQhZw8rPfY8=
 github.com/gethinode/mod-blocks v1.23.5 h1:nDEZ3995WNzNig1dnUfTtXtYm36K1ktbt5gckJhuD3U=
 github.com/gethinode/mod-blocks v1.23.5/go.mod h1:zSbs/OyzCDt4Kvn/9e1Zi8K1tweJANfibHUr/jcOrt4=
+github.com/gethinode/mod-blocks v1.23.6 h1:Kg0RAlMhz2j1W60sERvHQyAa8H6UbNfMl9ZJajh/vKU=
+github.com/gethinode/mod-blocks v1.23.6/go.mod h1:zSbs/OyzCDt4Kvn/9e1Zi8K1tweJANfibHUr/jcOrt4=
 github.com/gethinode/mod-bootstrap-icons v1.4.4 h1:ts9JkWlWYJ8fiPkMO5Ue6ym/2WM5V9Rq1qpAgSGnbxQ=
 github.com/gethinode/mod-bootstrap-icons v1.4.4/go.mod h1:ue9SPYxBc0NOoghr2qnWBz4NZF+sxOeb2sx+t9T2KKY=
 github.com/gethinode/mod-cookieyes/v2 v2.2.6 h1:/DQm8OYpms0On8wuosQER47TplVu/3z7MZHwbBKXCAg=

--- a/layouts/_shortcodes/example-bookshop.html
+++ b/layouts/_shortcodes/example-bookshop.html
@@ -38,7 +38,6 @@
 {{- $content := .InnerDeindent -}}
 {{- $padding := partial "utilities/GetPadding.html" -}}
 {{- $sectionClass := printf "p-1 px-md-%d py-md-%d" $padding.x $padding.y -}}
-{{- $bgClass := printf "m-n1 mx-md-n%d my-md-n%d" $padding.x $padding.y -}}
 
 {{- $data := "" -}}
 {{- $partial := "" -}}
@@ -52,7 +51,7 @@
         {{ $lang = (trim (index (split $content "\n") 2) "\x60") | default "yml" }}
         {{ $content = index (index $inputRE 0) 2 }}
         {{ $data = index (unmarshal $content) 0 }}
-        {{ $data = merge $data (dict "section_class" $sectionClass "bg_class" $bgClass) }}
+        {{ $data = merge $data (dict "section_class" $sectionClass) }}
         {{ $component_name := (index $data "_bookshop_name") }}
         {{ if not $component_name }}
             {{ errorf "Expected '_bookshop_name': %s" .Position -}}


### PR DESCRIPTION
Fixes the hero-with-backdrop preview on the Hero docs page, and pulls in the companion mod-blocks release.

## Problem

The backdrop image in the preview rendered 24px up and to the left of its section, leaving a matching gap on the bottom and right edges.

The `example-bookshop` shortcode pads the preview section (`p-1 px-md-4 py-md-4`) and passed the exact negative counterpart to the backdrop image via `bg_class` (`m-n1 mx-md-n4 my-md-n4`). That compensation was only correct while the image was laid out from its *static position*, at the section's content-box origin.

mod-blocks v1.23.5 (gethinode/mod-blocks#142) pins the backdrop with `inset: 0`, so the image now covers the section's padding box by construction. The negative margins became stale and displaced it.

## Changes

1. **Remove the `bg_class` negative margins** from `example-bookshop.html`. The section padding stays; the backdrop covers the section without compensation, and an author-specified `bg-class` in an example's YAML is now honoured instead of being overwritten.
2. **Bump mod-blocks to v1.23.6** (gethinode/mod-blocks#143), which anchors a backdrop to its own section whenever a backdrop is defined, rather than only when an overlay mode is set. Without it, a section combining `backdrop` with `overlay-mode: none` had no positioned ancestor and its image escaped to `<body>`.

## Verification

Backdrop geometry in the preview, measured in the browser before and after:

| | image rect | section rect |
|---|---|---|
| before | (213, 3464) 726×376 | (237, 3488) 726×376 |
| after | (237, 3488) 726×376 | (237, 3488) 726×376 |

A production build of the exampleSite on v1.23.6 confirms the backdrop section renders as `hero … backdrop-container background-container`, no `m-n1` margins remain on the page, and the `.backdrop-container` / `.background-container` / `.background-img-fluid` rules all survive PurgeCSS.

`hero.md` is the only docs page using `backdrop`, so this is the only preview affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)