### PR TITLE
fix(navbar): keep the navbar and body in sync when switching color mode

### DIFF
--- a/assets/js/navbar.js
+++ b/assets/js/navbar.js
@@ -167,7 +167,7 @@ function updateNavbar () {
 
       const targetTheme = defaultTheme ? defaultTheme : storedTheme
       if (targetTheme) {
-        navbar.setAttribute('data-bs-theme', defaultTheme)
+        navbar.setAttribute('data-bs-theme', targetTheme)
       }
     }
   }

--- a/assets/js/navbar.js
+++ b/assets/js/navbar.js
@@ -6,10 +6,6 @@ const colorsBG = ['body', 'secondary', 'tertiary']
 
 let scrollPosition = 0
 
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
 function getStyle(el, styleProp) {
     let y
     
@@ -65,7 +61,10 @@ function getBackgroundColor (section) {
 
   // use body background when section background is undefined or transparent
   if (color === 'rgba(0, 0, 0, 0)' || color === 'transparent') {
-    color = window.getComputedStyle(document.body).getPropertyValue('background-color')
+    const style = window.getComputedStyle(document.body)
+    // custom properties are not animated, so this yields the target color of a color mode
+    // switch rather than the intermediate color the body is currently fading through
+    color = style.getPropertyValue('--bs-body-bg').trim() || style.getPropertyValue('background-color')
   }
 
   return color
@@ -126,6 +125,18 @@ function parseRGB (color) {
       b: parseInt(match[3])
     }
   }
+
+  // custom properties such as --bs-body-bg resolve to a hex color
+  const hex = color.match(/^#([\da-f]{3}|[\da-f]{6})$/i)
+  if (hex) {
+    const digits = hex[1].length === 3 ? hex[1].replace(/./g, c => c + c) : hex[1]
+    return {
+      r: parseInt(digits.slice(0, 2), 16),
+      g: parseInt(digits.slice(2, 4), 16),
+      b: parseInt(digits.slice(4, 6), 16)
+    }
+  }
+
   return null
 }
 
@@ -214,12 +225,9 @@ if (navbar !== null && togglers !== null) {
     attributeFilter: ['data-bs-theme']
   }
   const Observer = new MutationObserver(() => {
-    if (fixed) {
-      // wait for the theme animation to finish
-      sleep(600).then(() => { 
-        updateNavbar() 
-      })
-    }
+    // switch along with the body rather than after it; the colors sampled by updateNavbar
+    // come from custom properties, which hold their target value from the outset
+    fixed && updateNavbar()
   })
   Observer.observe(html, config)
 

--- a/assets/scss/common/_styles.scss
+++ b/assets/scss/common/_styles.scss
@@ -1,6 +1,6 @@
 @if $enable-dark-mode {
     [data-bs-theme-animate="true"] body {
-        transition: background-color 0.5s, color 0.5s;
+        transition: $theme-mode-transition;
     }
 }
 

--- a/assets/scss/common/_variables-dart.scss
+++ b/assets/scss/common/_variables-dart.scss
@@ -51,6 +51,9 @@ $link-color-dark:                   mix(white, h.$primary, h.$dark-mode-tint) !d
 $primary-bg-subtle-dark:            mix(black, h.$primary, h.$dark-mode-shade) !default;
 $primary-border-subtle-dark:        mix(black, h.$primary, calc(h.$dark-mode-shade / 2)) !default;
 
+// Shared by every element that repaints on a color mode switch, so they stay in sync.
+$theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out, border-color .5s ease-in-out !default;
+
 $dropdown-transition: opacity .15s ease-in-out !default;
 $dropdown-horizontal-margin-top: calc((-1.5 * 1rem) - 2px);
 $dropdown-horizontal-padding-y: calc(1rem + 2px);

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -45,6 +45,11 @@ $primary-bg-subtle-dark:            mix(black, $primary, $dark-mode-shade) !defa
 $primary-border-subtle-dark:        mix(black, $primary, $dark-mode-shade / 2) !default;
 // scss-docs-end color-mode
 
+// scss-docs-start color-mode-transition
+// Shared by every element that repaints on a color mode switch, so they stay in sync.
+$theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out, border-color .5s ease-in-out !default;
+// scss-docs-end color-mode-transition
+
 // scss-docs-start horizontal-nav
 $dropdown-transition: opacity .15s ease-in-out !default;
 $dropdown-horizontal-margin-top: calc((-1.5 * 1rem) - 2px);

--- a/assets/scss/components/_navbar.scss
+++ b/assets/scss/components/_navbar.scss
@@ -85,7 +85,7 @@
 
 @if $enable-dark-mode {
     [data-bs-theme-animate="true"] .navbar {
-        transition: 0.5s ease-in-out;
+        transition: $theme-mode-transition;
     }
 }
 
@@ -102,7 +102,10 @@
 
 .navbar[data-transparent="true"] {
     backdrop-filter: none;
-    transition: all 0.3s ease;
+
+    // this rule would otherwise shadow the color mode transition, as it shares its
+    // specificity but comes later; keep the blur on its own, faster curve
+    transition: $theme-mode-transition, backdrop-filter 0.3s ease;
 
     &.navbar-scrolled {
         backdrop-filter: blur(10px);


### PR DESCRIPTION
Switching between light and dark mode changed the navbar and the body at visibly different times.

## Problem

The navbar does not inherit the document's color mode. `navbar.js` gives it its **own** `data-bs-theme` attribute so it can adapt to the section beneath it, and on a color mode switch that attribute was only reassigned after a hardcoded 600ms delay — longer than the body's 0.5s transition. The body finished fading before the navbar began.

Measured on the exampleSite, scrolled down, dark → light (background red channel):

| time | body | navbar |
|---|---|---|
| 0–537ms | 255 → 33 (fading) | 255 (unchanged) |
| 604ms | 33 (settled) | attribute finally flips |
| 604–1137ms | 33 | 255 → 33 (fading) |

Two smaller defects compounded it:

- The body and navbar each declared their own transition. The body omitted a timing function and so defaulted to `ease`, while the navbar asked for `ease-in-out`. Same 0.5s, but they diverged by up to 77/255 mid-flight.
- A transparent navbar was worse: `.navbar[data-transparent="true"]` shares the specificity of the color mode rule but comes later, so it replaced the transition entirely and animated over 0.3s.

## Changes

Three commits, one per concern:

1. **`fix(theme)`** — define the transition once as `$theme-mode-transition` and use it for every element that repaints on a switch. The transparent navbar keeps its faster curve for the backdrop blur, which is a scroll effect, not a color mode one.
2. **`fix(navbar)`** — assign `targetTheme` rather than `defaultTheme`, which was `null` at the top of a page without an overlay and stored the string `"null"`.
3. **`fix(navbar)`** — drop the 600ms delay. It existed because the navbar samples the background beneath it and would otherwise read a color the body is still fading through. Reading `--bs-body-bg` instead solves that at the source: custom properties are not animated, so the property holds the target color from the outset. Sampling no longer depends on the transition, so the navbar updates immediately and the delay (and its `sleep` helper) can go.

## Verification

Sampled both elements every animation frame through real toggles. Maximum divergence in the background red channel, previously up to 77/255 with the navbar a further ~600ms behind:

| case | result |
|---|---|
| scrolled, both directions | gap 0 — in sync |
| at top, both directions | gap 0 — in sync |
| transparent navbar, scrolled | gap 0 — in sync |

The behaviour the changed rules protect still works: the navbar's theme attribute is a valid mode at every scroll position, `data-bs-overlay` still wins at the top of an overlay page, and the transparent navbar is still clear at the top with `blur(10px)` once scrolled. The transparent cases were exercised by temporarily enabling `navigation.transparent`, which is off in the exampleSite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)