### PR TITLE
fix(scss): declare theme-mode-transition default at point of use

### DIFF
--- a/assets/scss/common/_styles.scss
+++ b/assets/scss/common/_styles.scss
@@ -1,3 +1,9 @@
+// Self-sufficient default: child themes commonly shadow common/_variables.scss
+// with their own fork, which silently drops variables added upstream. Declaring
+// the default at the point of use keeps the build working either way; a fork
+// that does define the variable still wins through !default.
+$theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out, border-color .5s ease-in-out !default;
+
 @if $enable-dark-mode {
     [data-bs-theme-animate="true"] body {
         transition: $theme-mode-transition;

--- a/assets/scss/components/_navbar.scss
+++ b/assets/scss/components/_navbar.scss
@@ -1,5 +1,9 @@
 // stylelint-disable annotation-no-unknown
 
+// Self-sufficient default — see common/_styles.scss for the rationale
+// (child themes shadowing common/_variables.scss).
+$theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out, border-color .5s ease-in-out !default;
+
 // adapted from https://www.codeply.com/p/UsTEwDkzNp#
 .checkbox {
 	opacity: 0;


### PR DESCRIPTION
## Summary

Child themes commonly ship their own fork of `common/_variables.scss` / `_variables-dart.scss`, which shadows hinode's copy in Hugo's union filesystem. Any variable added upstream to that file silently disappears from such themes, and the Sass compile fails with an undefined variable the moment a component references it.

This happened with `$theme-mode-transition` (added in 34bcd18d): downstream theme-infusal broke on the v2.15.1 → v2.19.3 bump with

```text
_navbar.scss:93:20: Undefined variable
```

## Fix

Declare the `!default` at the two consuming files (`common/_styles.scss`, `components/_navbar.scss`) so the compile is self-sufficient regardless of what the child theme's variables fork contains. A fork that does define the variable still wins through `!default` semantics; CSS output is unchanged.

## Verification

- Development build of the exampleSite passes; stylelint/eslint/markdownlint clean.
- Reproduced the downstream failure (theme-infusal + hinode v2.19.3) and confirmed it builds green against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)