### PR TITLE
feat(padding): opt-in mobile padding via PaddingClasses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gethinode/mod-lottie/v2 v2.1.2 // indirect
 	github.com/gethinode/mod-mermaid/v4 v4.10.1 // indirect
 	github.com/gethinode/mod-simple-datatables/v3 v3.1.2 // indirect
-	github.com/gethinode/mod-utils/v5 v5.23.4 // indirect
+	github.com/gethinode/mod-utils/v5 v5.24.0 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/gethinode/mod-utils/v5 v5.23.3 h1:ifcDyTYpmM6HBzc6SbpG+hJMSCfGTZKf/pl
 github.com/gethinode/mod-utils/v5 v5.23.3/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
 github.com/gethinode/mod-utils/v5 v5.23.4 h1:/lcKi1MJ2srGfNhCPtdnTRpQgdh2FNBRUAS7Ysz1W34=
 github.com/gethinode/mod-utils/v5 v5.23.4/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
+github.com/gethinode/mod-utils/v5 v5.24.0 h1:dqqRn6qaEehEHZjo74pxbzvVdCn++XuZk18jxeUvwwA=
+github.com/gethinode/mod-utils/v5 v5.24.0/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
 github.com/nextapps-de/flexsearch v0.0.0-20250907103239-defb38b083f0 h1:55phPhe6fDjfjG0jX4+br3nLORKgjgx8abZUdI0YJRA=
 github.com/nextapps-de/flexsearch v0.0.0-20250907103239-defb38b083f0/go.mod h1:5GdMfPAXzbA2gXBqTjC6l27kioSYzHlqDMh0+wyx7sU=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 h1:QDKcU3q39lFGzdVwM6kgCGnW3ibbMfYIi0Rwl62iJpo=

--- a/layouts/_partials/assets/navbar.html
+++ b/layouts/_partials/assets/navbar.html
@@ -130,7 +130,7 @@
 {{/* Main code */}}
 <div class="container-fluid {{ if $args.fixed }}fixed-top{{ else if $overlay }}navbar-overlay{{ end }} p-0{{ with $class }} {{ . }}{{ end }}">
     {{- partial "assets/page-alert.html" (dict "page" $page) -}}
-    <nav class="navbar px-{{ $padding.x }} py-{{ $padding.y }} navbar-fs-{{ $fs }} navbar-{{ $args.breakpoint }}-fs
+    <nav class="navbar {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }} navbar-fs-{{ $fs }} navbar-{{ $args.breakpoint }}-fs
         {{- if not $overlay }}{{ with $color }} bg-{{ . }}{{ end }}{{ end -}}
         {{ if $args.fixed }} navbar-fixed-top{{ end }} navbar-expand-{{ $args.breakpoint -}}
         {{ if $contrast }} navbar-contrast{{ end }}"

--- a/layouts/_partials/footer/social.html
+++ b/layouts/_partials/footer/social.html
@@ -2,7 +2,7 @@
     {{- $padding := partial "utilities/GetPadding.html" -}}
     {{- $tab := site.Params.main.externalLinks.tab -}}
     <div class="container-fluid bg-primary bg-opacity-{{ .Site.Params.style.themeOpacity | default "25" | safeHTML }}">
-        <div class="container-xxl px-{{ $padding.x }} px-xxl-0">
+        <div class="container-xxl {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} px-xxl-0">
             <div class="row row-cols-2 py-3 align-items-center">
                 <div class="col col-6">
                     <div class="row justify-content-end p-0">

--- a/layouts/docs/all.html
+++ b/layouts/docs/all.html
@@ -15,7 +15,7 @@
     {{- partial "page/sidebar-offcanvas.html" (dict "section" $.Section "raw" $sidebar) -}}
 
     {{/* Render the page content using responsive columns */}}
-    <div class="container-xxl flex-fill py-{{ $padding.y }} px-{{ $padding.x }} px-xxl-0">
+    <div class="container-xxl flex-fill {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} px-xxl-0">
         <div class="row row-cols-1 row-cols-{{ $breakpoint.current }}-2 row-cols-{{ $breakpoint.next }}-3">
             <div class="col col-{{ $breakpoint.next }}-2 d-none d-{{ $breakpoint.next }}-block sidebar-overflow sticky-top p-0">
                 {{ $sidebar | safeHTML }}

--- a/layouts/docs/header.html
+++ b/layouts/docs/header.html
@@ -27,7 +27,7 @@
 
 {{/* Display description */}}
 {{ with .Description }}
-    <div class="{{ $contentStyle }} py-{{ $padding.y }}">{{ . | $.RenderString | safeHTML }}</div>
+    <div class="{{ $contentStyle }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }}">{{ . | $.RenderString | safeHTML }}</div>
 {{ end }}
 
 {{/* Display TOC dropdown on smaller screens */}}

--- a/layouts/form/single.html
+++ b/layouts/form/single.html
@@ -2,7 +2,7 @@
     {{- $padding := partial "utilities/GetPadding.html" -}}
     {{- $formIcon := partial "utilities/GetThemeIcon.html" (dict "id" "formSubmittedIcon" "default" "fa envelope") -}}
     <section class="container-fluid p-0 section-cover d-flex align-items-center">
-        <div class="container-xxl px-xxl-0 px-{{ $padding.x }} py-0 my-auto h-100">
+        <div class="container-xxl px-xxl-0 {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} py-0 my-auto h-100">
             <div class="text-center col-md-6 mx-auto">
                 <span class="text-body fw-bold">
                     {{ partial "assets/icon.html" (dict "icon" $formIcon "class" "fa-10x") }}

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -29,7 +29,7 @@
 
 {{/* Display description */}}
 {{ with .Description }}
-    <div class="{{ $contentStyle }} py-{{ $padding.y }}">{{ . | $.RenderString | safeHTML }}</div>
+    <div class="{{ $contentStyle }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }}">{{ . | $.RenderString | safeHTML }}</div>
 {{ end }}
 
 {{/* Display TOC dropdown on smaller screens */}}

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -8,7 +8,7 @@
         {{- partial "page/blocks.html" . -}}
     {{ else }}
         {{ with partial "page/articles.html" . }}
-            <div class="container-xxl py-{{ $padding.y }} px-xxl-0 px-{{ $padding.x }} py-0 my-auto h-100">
+            <div class="container-xxl {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }} px-xxl-0 {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} py-0 my-auto h-100">
                 {{ . | safeHTML }}
             </div>
         {{ end }}
@@ -16,7 +16,7 @@
 
     <!-- Render the list page content as full width, if any -->
     {{ with $content }}
-        <div class="container-xxl flex-fill py-{{ $padding.y }} px-{{ $padding.x }} px-xxl-0">
+        <div class="container-xxl flex-fill {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} px-xxl-0">
             {{ . }}
         </div>
     {{ end }}

--- a/layouts/minimal/header.html
+++ b/layouts/minimal/header.html
@@ -14,5 +14,5 @@
 
 {{/* Display description */}}
 {{ with .Description }}
-    <div class="{{ $contentStyle }} py-{{ $padding.y }}">{{ . | $.RenderString | safeHTML }}</div>
+    <div class="{{ $contentStyle }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }}">{{ . | $.RenderString | safeHTML }}</div>
 {{ end }}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -13,7 +13,7 @@
     {{/*    Column 3: sharing buttons and TOC navigation or specials (CTA), visible in large viewports */}}
     {{/*              content is folded into main column (handled by page elements) */}}
     {{ if (gt (len .RawContent) 0) }}
-        <div class="container-xxl flex-fill py-{{ $padding.y }} px-{{ $padding.x }} px-xxl-0">
+        <div class="container-xxl flex-fill {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} px-xxl-0">
             <div class="row row-cols-1 row-cols-{{ $breakpoint.current }}-2 row-cols-{{ $breakpoint.next }}-3">
                 <div class="col col-{{ $breakpoint.next }}-2 d-none d-{{ $breakpoint.next }}-block sidebar-overflow sticky-top p-0">
                     {{ $sidebar | safeHTML }}

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -5,7 +5,7 @@
     {{- $padding := partial "utilities/GetPadding.html" -}}
     {{- $pageTitle := .Page.Title }}
     {{ if and site.Params.main.titleCase (not .Page.Params.exact) }}{{ $pageTitle = title $pageTitle }}{{ end }}
-        <div class="container-xxl flex-fill py-{{ $padding.y }} px-{{ $padding.x }} px-xxl-0">
+        <div class="container-xxl flex-fill {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} px-xxl-0">
             <div class="row row-cols-1 row-cols-{{ $breakpoint.current }}-2 row-cols-{{ $breakpoint.next }}-3">
                 <div class="col col-{{ $breakpoint.next }}-2 d-none d-{{ $breakpoint.next }}-block">
                 </div>


### PR DESCRIPTION
## Summary

Consumes mod-utils v5.24.0's opt-in `[*.padding.mobile]` support: the section-level padding interpolations (page shells, headers, footer social, navbar) now compose their classes via the `PaddingClasses` partial. Sites that configure a mobile padding get `px-2 px-md-4`-style responsive utilities below the md breakpoint; sites that don't get **byte-identical output** (verified with a full-site class-string diff of the exampleSite against main — empty).

Ten consumer sites swapped: single, list (×2), tags/list, docs/all, header, docs/header, minimal/header, form/single, footer/social, navbar (navigation section, falls back to main's mobile values per the existing chain).

## Deliberately not swapped

- `page/articles.html`, `assets/links.html`, `assets/card.html`, `assets/card-group.html`, `assets/nav.html`, `assets/timeline.html`, `assets/section-title.html` — internal component rhythm, not section padding.
- `_shortcodes/example-bookshop.html` — already mobile-aware by construction (`p-1 px-md-*`).
- `head/stylesheet.html`'s `padding-x` SCSS var — SCSS keeps the regular value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)