### PR TITLE
fix: restore v5 rendering parity for hero images and dropdowns

### DIFF
--- a/assets/scss/components/_nav.scss
+++ b/assets/scss/components/_nav.scss
@@ -134,3 +134,10 @@
         }
     }
 }
+
+/* Clip dropdown items to the menu's rounded corners; sites may enlarge the
+   global border radius (--bs-border-radius), which dropdowns inherit, and
+   active items would otherwise overflow the curve. */
+.dropdown-menu {
+    overflow: hidden;
+}

--- a/data/structures/hero-image.yml
+++ b/data/structures/hero-image.yml
@@ -13,4 +13,7 @@ arguments:
   wrapper:
   class:
   image-overlay:
-  justify:
+  # no inherited default: the image centers by default and only applies md
+  # justification when the caller sets it explicitly (v5 semantics; callers
+  # historically passed an empty string that the legacy engine suppressed)
+  justify: { default: }


### PR DESCRIPTION
Visual-review fixes from the gethinode.com v6-generation validation session:
- hero-image: suppress the inherited justify default (callers historically passed an empty string the v5 engine swallowed; the v6 default shifted image alignment at md+ on 25 rendered instances)
- nav: clip dropdown items to rounded menu corners (pre-existing glitch on sites enlarging the global border radius)

🤖 Generated with [Claude Code](https://claude.com/claude-code)