### PR TITLE
fix(preview): stop caching the embedding verdict indefinitely

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -180,3 +180,15 @@ home = ["HTML", "RSS", "REDIR", "netlify", "server", "searchindex"]
        kind = '{home}'
        output = '{netlify,server}'
 # toml-docs-end segments
+
+# toml-docs-start caches
+[caches]
+  # Hugo caches remote resources forever by default, and the Netlify cache plugin carries that
+  # cache across builds. The preview component reads a target's response headers to decide whether
+  # it can be embedded, so a stale entry pins the verdict to whatever the target sent the first
+  # time it was fetched: correcting a target's CSP then no longer takes effect on a rebuild.
+  # Builds are further apart than this, so headers are re-read on every build while still being
+  # fetched only once within one.
+  [caches.getresource]
+    maxAge = "5m"
+# toml-docs-end caches

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gethinode/mod-blocks/v2 v2.1.0 // indirect
 	github.com/gethinode/mod-bootstrap-icons/v2 v2.0.0 // indirect
 	github.com/gethinode/mod-cookieyes/v2 v2.2.6 // indirect
-	github.com/gethinode/mod-docs v1.15.0 // indirect
+	github.com/gethinode/mod-docs v1.15.1 // indirect
 	github.com/gethinode/mod-fontawesome/v6 v6.0.0 // indirect
 	github.com/gethinode/mod-leaflet/v3 v3.1.0 // indirect
 	github.com/gethinode/mod-utils/v6 v6.4.0 // indirect

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gethinode/mod-cookieyes/v2 v2.2.6 // indirect
 	github.com/gethinode/mod-docs v1.15.0 // indirect
 	github.com/gethinode/mod-fontawesome/v6 v6.0.0 // indirect
+	github.com/gethinode/mod-leaflet/v3 v3.1.0 // indirect
 	github.com/gethinode/mod-utils/v6 v6.4.0 // indirect
 	github.com/twbs/icons v1.13.1 // indirect
 )

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -18,6 +18,8 @@ github.com/gethinode/mod-docs v1.15.0 h1:A/iJ2S2v8Le0u8gdOfpLoss8mDaaJI+gtMNXiws
 github.com/gethinode/mod-docs v1.15.0/go.mod h1:ru1w0fHqFocjDIMV0dm40OwhBw5k4UncCS8iO/1S5kI=
 github.com/gethinode/mod-fontawesome/v6 v6.0.0 h1:PrfiMfVEAM5Lpnkp+sXOtOdRSOe3l56z+ngrPcACzlA=
 github.com/gethinode/mod-fontawesome/v6 v6.0.0/go.mod h1:ayMslv2xpC5cjxUVTkIlFBbOd1LM5ezIr0OSOr6q8Gk=
+github.com/gethinode/mod-leaflet/v3 v3.1.0 h1:zscIv/q2dg0TUjosjM9hB9DchlutuWkWqOafX00fsKI=
+github.com/gethinode/mod-leaflet/v3 v3.1.0/go.mod h1:FsoyVRb3DRZBb2jWPV4yJNqbmOKmCwaJgom2hbWZXnA=
 github.com/gethinode/mod-utils/v6 v6.4.0 h1:l49KrawKE/7c6XE00wXQ9T5/kuTfiETerBz6OWn3SJc=
 github.com/gethinode/mod-utils/v6 v6.4.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/twbs/icons v1.13.1 h1:6bmNXvoeIbvjFWjfbjXg5JGbelLD1haIsMaEIzE9UZI=

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -16,6 +16,8 @@ github.com/gethinode/mod-docs v1.14.1 h1:+G8IjMi/krhAzvOlB5ODnfQCp6b5ixWyU3D7f/8
 github.com/gethinode/mod-docs v1.14.1/go.mod h1:ru1w0fHqFocjDIMV0dm40OwhBw5k4UncCS8iO/1S5kI=
 github.com/gethinode/mod-docs v1.15.0 h1:A/iJ2S2v8Le0u8gdOfpLoss8mDaaJI+gtMNXiws7SyE=
 github.com/gethinode/mod-docs v1.15.0/go.mod h1:ru1w0fHqFocjDIMV0dm40OwhBw5k4UncCS8iO/1S5kI=
+github.com/gethinode/mod-docs v1.15.1 h1:WSmJWWhbiXeRkNqYRnZMBT5GkMDaJsijYC6YZzMcvkA=
+github.com/gethinode/mod-docs v1.15.1/go.mod h1:ru1w0fHqFocjDIMV0dm40OwhBw5k4UncCS8iO/1S5kI=
 github.com/gethinode/mod-fontawesome/v6 v6.0.0 h1:PrfiMfVEAM5Lpnkp+sXOtOdRSOe3l56z+ngrPcACzlA=
 github.com/gethinode/mod-fontawesome/v6 v6.0.0/go.mod h1:ayMslv2xpC5cjxUVTkIlFBbOd1LM5ezIr0OSOr6q8Gk=
 github.com/gethinode/mod-leaflet/v3 v3.1.0 h1:zscIv/q2dg0TUjosjM9hB9DchlutuWkWqOafX00fsKI=

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gethinode/mod-fontawesome/v6 v6.0.0 // indirect
 	github.com/gethinode/mod-google-analytics/v2 v2.0.3 // indirect
 	github.com/gethinode/mod-katex v1.1.5 // indirect
-	github.com/gethinode/mod-leaflet/v3 v3.0.0 // indirect
+	github.com/gethinode/mod-leaflet/v3 v3.1.0 // indirect
 	github.com/gethinode/mod-lottie/v3 v3.0.0 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.0 // indirect
 	github.com/gethinode/mod-simple-datatables/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/gethinode/mod-leaflet/v2 v2.1.1 h1:8g0T9hN036LsCaXFkehDlzFbEpAlSYrzxS
 github.com/gethinode/mod-leaflet/v2 v2.1.1/go.mod h1:A9Inp9uwSDD6vW8uYVVGl6eXGMe+j3ESOxV4T53HOaM=
 github.com/gethinode/mod-leaflet/v3 v3.0.0 h1:rNjdruvS08bxqsLFEWNt9aU2KCbHiRlEKpKIutqWVOw=
 github.com/gethinode/mod-leaflet/v3 v3.0.0/go.mod h1:FsoyVRb3DRZBb2jWPV4yJNqbmOKmCwaJgom2hbWZXnA=
+github.com/gethinode/mod-leaflet/v3 v3.1.0 h1:zscIv/q2dg0TUjosjM9hB9DchlutuWkWqOafX00fsKI=
+github.com/gethinode/mod-leaflet/v3 v3.1.0/go.mod h1:FsoyVRb3DRZBb2jWPV4yJNqbmOKmCwaJgom2hbWZXnA=
 github.com/gethinode/mod-lottie/v2 v2.0.1 h1:jIY5oGHtkXXvJoxNAE2AueoqxqNNlTYHF4+igQmkIAU=
 github.com/gethinode/mod-lottie/v2 v2.0.1/go.mod h1:/YzhRcG9H8MyODt8qaOQP0nqoux7EFHW2S7ugiiFf0o=
 github.com/gethinode/mod-lottie/v2 v2.1.0 h1:d0ViSsZr8idst7/zWTjCHp93jdX9fPHeGaAHEhi7lO4=


### PR DESCRIPTION
## Problem

Hugo caches remote resources **forever** by default (`caches.getresource` `maxAge = -1`), and
`netlify-plugin-hugo-cache-resources` carries that cache from build to build.

The preview component reads a target's response headers to decide whether it can be embedded — so a
stale cache entry pins the verdict to whatever the target sent the *first* time it was fetched.
Correcting a target's CSP then has no effect on a rebuild.

This is not a theoretical risk. After gethinode/gethinode.com#154, gethinode/hinode#2008 and
gethinode/theme-agency#384 all merged and deployed, the **Agency** and **Hinode (classic)**
showcases stayed on their fallback screenshots, even though:

- `demo.gethinode.com` and `theme-agency.gethinode.com` now send `frame-ancestors 'self' gethinode.com`
- gethinode.com's `frame-src` allows them
- gethinode.com had since rebuilt (the mod-leaflet bump went live in that same build)

The rebuild re-read the *old* headers out of the cache. Recovering requires a cache-cleared deploy,
and nothing in the build output says so — it just silently keeps showing screenshots.

## Change

Cap the lifetime of the remote-resource cache:

```toml
[caches]
  [caches.getresource]
    maxAge = "5m"
```

Builds are further apart than five minutes, so headers are re-read on every build, while a single
build still fetches each one only once. `getresource` also backs remote images (mod-utils) and video
posters (hinode), so the cache is shortened rather than disabled — those are re-fetched per build,
not per use.

Also upgrades **mod-leaflet to v3.1.0** (gethinode/mod-leaflet#266), which gives the map cooperative
gestures. The map on `/docs/components/map` trapped page scroll until now; gethinode.com already has
this bump, the demo did not.

## Verification

Built the exampleSite with the new module vendored:

- Hugo parses the cache setting: `[caches.getresource] maxage = '5m0s'`.
- The demo's map page carries the gesture wiring (`data-leaflet-hint-zoom`, `data-leaflet-hint-drag`),
  and the overlay styles compile into the leaflet CSS bundle.
- mod-leaflet ships an `i18n` mount for the first time, so I checked it resolves: a Dutch page renders
  `"Gebruik twee vingers om de kaart te verplaatsen"`.
- `netlify.toml` is unchanged — neither change affects the published headers.

> Note: the module bump only takes effect after `pnpm mod:vendor`; a stale `_vendor/` silently
> shadows it (`hugo mod graph` showed `mod-leaflet@v3.0.0+vendor` until I re-vendored). Netlify
> re-vendors on every build, so this only bites locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)