### PR TITLE
fix(build): derive theme version from the built commit

### DIFF
--- a/data/netlify.toml
+++ b/data/netlify.toml
@@ -1,7 +1,7 @@
 # toml-docs-start netlify
 [build]
     publish = "exampleSite/public"
-    command = "HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run build:example"
+    command = "git fetch --tags --force > /dev/null 2>&1; HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0 2> /dev/null) npm run build:example"
 
 [build.environment]
     DART_SASS_VERSION = "1.98.0"
@@ -13,14 +13,14 @@
 # toml-docs-end netlify
 
 [context.deploy-preview]
-    command = "HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run build:example -- -b $DEPLOY_PRIME_URL"
+    command = "git fetch --tags --force > /dev/null 2>&1; HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0 2> /dev/null) npm run build:example -- -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy]
-    command = "HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run build:example -- -b $DEPLOY_PRIME_URL"
+    command = "git fetch --tags --force > /dev/null 2>&1; HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0 2> /dev/null) npm run build:example -- -b $DEPLOY_PRIME_URL"
 
 [dev]
     framework = "#custom"
-    command = "HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run start:example"
+    command = "git fetch --tags --force > /dev/null 2>&1; HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0 2> /dev/null) npm run start:example"
     targetPort = 1313
     port = 8888
     publish = "public"

--- a/layouts/_partials/assets/version.html
+++ b/layouts/_partials/assets/version.html
@@ -13,24 +13,25 @@
     {{- $result := "" -}}
     {{- if gt (len $match) 0 -}}
         {{- $result = (index (split (index $match 0) " ") 1) -}}
-        {{- $result = strings.TrimPrefix "v" $result -}}
     {{- end -}}
 
     {{- return $result -}}
 {{- end -}}
 
-{{/* 
+{{/*
     Fallback to initialize the Hinode version from an environment variable. This applies to the main
-    Hinode repository including the example site (which is published to demo.gethinode.com). The following
-    command initializes the HUGO_HINODE_VERSION using the relevant git tag on macOS/Linux:
-    HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run build:example
+    Hinode repository including the example site (which is published to demo.gethinode.com), as it
+    resolves Hinode as a local workspace module instead of a versioned dependency. The following command
+    initializes the HUGO_HINODE_VERSION using the latest tag of the built commit on macOS/Linux:
+    HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0) npm run build:example
 */}}
 {{- define "_partials/inline/env-version.html" -}}
     {{ return getenv "HUGO_HINODE_VERSION"  }}
 {{- end -}}
 
 {{- $version := partial "inline/mod-version.html" . -}}
-{{ if not $version }}
-    {{- $version = partial "inline/env-version.html" . | default "unknown-revision" -}}
-{{ end }}
+{{- if not $version -}}
+    {{- $version = partial "inline/env-version.html" . -}}
+{{- end -}}
+{{- $version = $version | default "unknown-revision" | strings.TrimPrefix "v" -}}
 {{- print $version -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 # Auto-generated file - do not modify
 [build]
-  command = 'HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run build:example'
+  command = 'git fetch --tags --force > /dev/null 2>&1; HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0 2> /dev/null) npm run build:example'
   publish = 'exampleSite/public'
 
   [build.environment]
@@ -13,14 +13,14 @@
 
 [context]
   [context.branch-deploy]
-    command = 'HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run build:example -- -b $DEPLOY_PRIME_URL'
+    command = 'git fetch --tags --force > /dev/null 2>&1; HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0 2> /dev/null) npm run build:example -- -b $DEPLOY_PRIME_URL'
 
   [context.deploy-preview]
-    command = 'HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run build:example -- -b $DEPLOY_PRIME_URL'
+    command = 'git fetch --tags --force > /dev/null 2>&1; HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0 2> /dev/null) npm run build:example -- -b $DEPLOY_PRIME_URL'
 
 [dev]
   autoLaunch = false
-  command = 'HUGO_HINODE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) npm run start:example'
+  command = 'git fetch --tags --force > /dev/null 2>&1; HUGO_HINODE_VERSION=$(git describe --tags --abbrev=0 2> /dev/null) npm run start:example'
   framework = '#custom'
   port = 8888
   publish = 'public'


### PR DESCRIPTION
## Problem

The example site published to [demo.gethinode.com](https://demo.gethinode.com/en/) reports a theme version unrelated to the code it was built from:

```html
<meta name=theme content="Hinode v2.0.0-beta.29">
```

It is not a stale deploy. The deployed site's fingerprinted JS bundle (`critical.bundle.min.aaf9b038067f`) is identical to a local build of the v3.0.3 commit, so the demo *was* built from current source and still printed a tag from December 2025.

## Root cause

The example site resolves Hinode as a local workspace module (`hinode.work`), so `exampleSite/go.mod` has no `github.com/gethinode/hinode` require line. The go.mod lookup in `assets/version.html` therefore always comes up empty and every example build falls through to the `HUGO_HINODE_VERSION` fallback, which `netlify.toml` computed as:

```sh
git describe --tags $(git rev-list --tags --max-count=1)
```

That asks *"what is the newest tag anywhere in the clone?"* — a question whose answer is independent of the commit being built. Netlify reuses a cached clone and fetches only the deployed branch ref, so it never pulled the new v3 tags and the newest tag it could see was `v2.0.0-beta.29`. Locally, with all tags present, the same command returns `v3.0.3`, which is why this stayed invisible in local testing.

A second, cosmetic defect: only the go.mod path stripped the leading `v`. That is why the demo rendered `Hinode v2.0.0-beta.29` while a real consumer site (gethinode.com) renders `Hinode 3.0.1`.

## Changes

- **Describe the built commit.** Fetch tags first, then `git describe --tags --abbrev=0`, across all four Netlify contexts. Edited in `data/netlify.toml` (the source) with `netlify.toml` regenerated via `npm run build:headers`.
- **Strip the `v` prefix once**, at the single exit point of `assets/version.html`, so the environment fallback and the go.mod path agree.

## Verification

- Simulated Netlify's cached clone (holds the v3.0.3 commit, missing the new tags): the old command returns a tag unrelated to `HEAD`; the new command returns `v3.0.3`.
- Consumer path, isolated site with a real `require github.com/gethinode/hinode/v3 v3.0.3`: emits `3.0.3`, and go.mod still takes precedence over the env var — no regression for sites like gethinode.com.
- `npm run build:example` with the new command emits `<meta name=theme content="Hinode 3.0.1">` on `develop` (correct: `develop` sits at v3.0.1 plus commits; v3.0.2/v3.0.3 were tagged on `main`). On `main` it resolves to `3.0.3`.
- `npm test` passes with 0 errors.

## Note

A plain `npm run build:example` with no env var still emits `Hinode unknown-revision`, since the example site has no version to read from go.mod. Closing that would mean giving the repo a committed source of version truth (e.g. having semantic-release bump `package.json`, which today stays at `0.0.0-semantically-released`). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)