### PR TITLE
fix(components): correct the release version of the resize argument

### DIFF
--- a/data/structures/example.yml
+++ b/data/structures/example.yml
@@ -19,7 +19,7 @@ arguments:
     comment: >-
       Adds a grip to the lower-right corner of the preview, allowing the reader to
       resize the preview horizontally. Requires `show-preview` to be enabled.
-    release: v3.1.0
+    release: v3.2.0
   # deprecated arguments
   show_markup:
     type: bool


### PR DESCRIPTION
The `resize` argument added in #2019 is annotated `release: v3.1.0`, but it actually shipped in **v3.2.0** — semantic-release had already cut v3.1.0 for the data-table `wrap` feature while #2019 was in review.

Verified:

```
$ git show v3.1.0:data/structures/example.yml | grep -c '^  resize:'   # 0
$ git show v3.2.0:data/structures/example.yml | grep -c '^  resize:'   # 1
$ git tag --contains e9141262                                          # v3.2.0
```

This matters because the annotation drives the version badge in the generated argument table. As it stands, a reader on v3.1.0 would see `resize` advertised as available, use it, and hit a hard build failure (`unsupported argument 'resize'`, exit 1).

One-line fix; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)