### PR TITLE
build(deps): bump mod-flexsearch to v5.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/airbnb/lottie-web v5.13.0+incompatible // indirect
 	github.com/gethinode/mod-bootstrap v1.3.7 // indirect
 	github.com/gethinode/mod-csp v1.0.12 // indirect
-	github.com/gethinode/mod-flexsearch/v5 v5.0.1 // indirect
+	github.com/gethinode/mod-flexsearch/v5 v5.0.2 // indirect
 	github.com/gethinode/mod-fontawesome/v6 v6.0.1 // indirect
 	github.com/gethinode/mod-google-analytics/v2 v2.0.4 // indirect
 	github.com/gethinode/mod-katex v1.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/gethinode/mod-flexsearch/v5 v5.0.0 h1:JsrsKejSRxirUyfCZheLFkQVAJKdtRD
 github.com/gethinode/mod-flexsearch/v5 v5.0.0/go.mod h1:FGj0l97PX7OnDjvFtdFrq3g3BJPeal7FiSgrtd6Yxdo=
 github.com/gethinode/mod-flexsearch/v5 v5.0.1 h1:/0K2nlJ53+PyQjyyl14S9SGpmJRV/vy5V4I71KbL6Qc=
 github.com/gethinode/mod-flexsearch/v5 v5.0.1/go.mod h1:RKNSsvoFRnEfQftB/o9IrX4YBLeS27HH9AgnpYYSd24=
+github.com/gethinode/mod-flexsearch/v5 v5.0.2 h1:VAHzYLJECrVBvzn5xvM+FoHSP2VwDDPlUrfJDL8G/gg=
+github.com/gethinode/mod-flexsearch/v5 v5.0.2/go.mod h1:0kRR1xaAhSYVyVICV5+x5bF8OSpfre1DwLdrK3a5uAA=
 github.com/gethinode/mod-fontawesome/v4 v4.0.3 h1:ml+V7YPkxsK5sPJz0OlheBlGdEZrry4aH/7M/ytz3zk=
 github.com/gethinode/mod-fontawesome/v4 v4.0.3/go.mod h1:EqAF4dW3gyUr/CsNND5lEPJcNRlLJ+GfPIUaGTaVRic=
 github.com/gethinode/mod-fontawesome/v4 v4.1.1 h1:nC2tTBHTeUBwVqZCz6kEzDvuBrbMgWeOxcAXbCBwCOs=


### PR DESCRIPTION
## Summary

Picks up [mod-flexsearch v5.0.2](https://github.com/gethinode/mod-flexsearch/releases/tag/v5.0.2), which caps search result descriptions at 100 characters.

Pages without a frontmatter `description` fall back to their summary, and Hugo's summary will not split a block element — so a page opening with a table swallowed the whole table into the search index and flooded the suggestion dropdown.

## Verified against this example site

- `table-demo`'s indexed description drops from **1,899 characters** (carrying a literal `&nbsp;`) to **99**: `"Plain wrapped table Name Type Description alpha widget The first record, with a description long..."`
- French descriptions still render real apostrophes (`Rencontrez notre équipe d'experts.`), confirming the upstream fix for Hugo's `truncate` HTML-escaping its input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)