### PR TITLE
fix(shortcodes): make a minimal nav build and render

### DIFF
--- a/exampleSite/content/en/id-demo.md
+++ b/exampleSite/content/en/id-demo.md
@@ -74,3 +74,12 @@ title: Id Demo
 {{</* toast */>}}Second toast.{{</* /toast */>}}
 {{< /example >}}
 <!-- markdownlint-enable MD037 -->
+
+## Minimal nav (no parent args, single item)
+
+Rendered directly (not via the example shortcode): a single-item nav whose parent
+has no arguments. This is the most natural nav usage and it used to crash the build.
+
+{{< nav >}}
+{{< nav-item title="Only tab" show="true" >}}A single-item nav whose parent has no arguments.{{< /nav-item >}}
+{{< /nav >}}

--- a/layouts/_shortcodes/nav-item.html
+++ b/layouts/_shortcodes/nav-item.html
@@ -33,7 +33,7 @@
 
     {{- $fade := $args.fade -}}
     {{- $parentFade := false }}
-    {{- if isset .Parent.Params "fade" }}{{ $parentFade = partial "utilities/CastBool.html" (.Parent.Get "fade") }}{{ end -}}
+    {{- if and .Parent.IsNamedParams (isset .Parent.Params "fade") }}{{ $parentFade = partial "utilities/CastBool.html" (.Parent.Get "fade") }}{{ end -}}
     {{- $fade = or $fade $parentFade -}}
     {{- $title := or $args.title $args.header -}}
     {{- $itemID := printf "%s-btn-%d" $parent $id }}
@@ -69,7 +69,7 @@
         {{- .Parent.Scratch.Set "inner-icon" ($icons | append $args.icon) -}}
         {{- .Parent.Scratch.Set "inner-attrs" ($itemAttrs | append $args.attributes) -}}
     {{- else -}}
-        {{- .Parent.Scratch.Set "inner" $output -}}
+        {{- .Parent.Scratch.Set "inner" (print $output) -}}
         {{- .Parent.Scratch.Set "inner-title" (slice $title) -}}
         {{- .Parent.Scratch.Set "inner-disabled" (slice $disabledID) -}}
         {{- .Parent.Scratch.Set "inner-icon" (slice $args.icon) -}}


### PR DESCRIPTION
The most natural way to write a nav — one `{{< nav >}}` with no arguments and a single `{{< nav-item >}}` — failed two ways, both **pre-existing** (unrelated to any recent id work; `git blame` traces them to the v2.7.0 nav commit).

## Bug 1 — hard build crash

`nav-item.html` did `isset .Parent.Params "fade"`. When the parent nav is called with no *named* arguments, its `.Parent.Params` is a positional slice, and `isset` cannot index a slice with a string key:

```
isset unable to use key of type string as index
```

So `{{< nav >}}...{{< /nav >}}` (no args) crashed the whole site build. Guarded with `.Parent.IsNamedParams` — a named `fade` can only exist when the parent used named params — which is already an idiom in this file.

## Bug 2 — single-item nav doesn't render

A single nav-item stored its collected `inner` output as `template.HTML`, while the multi-item path stored a string (via `print $current $output`). The `nav-items` partial argument is typed `string`, so the single-item value was rejected by argument validation and the nav silently failed to render. The single-item branch now coerces with `print`, matching the multi-item branch exactly.

## Why they were masked

Every nav in the theme's own content happens to pass a named argument (dodging bug 1) and two or more items (dodging bug 2), so neither surfaced in normal use — only the minimal, most-obvious usage tripped them.

## Verification

Root-caused each with a reproduction, applied the minimal targeted fix for each, and confirmed the minimal nav now builds and renders with its tab button `aria-controls` correctly paired to its pane, its pane active and showing content, zero console errors. Existing multi-item navs are unaffected. A minimal no-args single-item nav is added to the `id-demo` fixture, rendered directly, so the build itself guards against a regression — if either bug returns, the build errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)