### PR TITLE
fix(deps): update mod-fontawesome to v6.0.2 for deterministic icon sprites

### DIFF
--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gethinode/mod-bootstrap-icons/v2 v2.0.1 // indirect
 	github.com/gethinode/mod-cookieyes/v2 v2.2.6 // indirect
 	github.com/gethinode/mod-docs v1.15.2 // indirect
-	github.com/gethinode/mod-fontawesome/v6 v6.0.1 // indirect
+	github.com/gethinode/mod-fontawesome/v6 v6.0.2 // indirect
 	github.com/gethinode/mod-utils/v6 v6.5.0 // indirect
 	github.com/twbs/icons v1.13.1 // indirect
 )

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -10,8 +10,8 @@ github.com/gethinode/mod-cookieyes/v2 v2.2.6 h1:/DQm8OYpms0On8wuosQER47TplVu/3z7
 github.com/gethinode/mod-cookieyes/v2 v2.2.6/go.mod h1:tULb7D7CoTycGUyL7ryqHJKaX11XuL2SN+XwP7/DI0Y=
 github.com/gethinode/mod-docs v1.15.2 h1:ZuOO/M5KyuUNGEoId+rManHG/L3WBboXG9L/ikSPNrY=
 github.com/gethinode/mod-docs v1.15.2/go.mod h1:ru1w0fHqFocjDIMV0dm40OwhBw5k4UncCS8iO/1S5kI=
-github.com/gethinode/mod-fontawesome/v6 v6.0.1 h1:Wq51kwbtlZYjLQdSbLjn1Qjf4ZkmGIbYrwxlO2vt9Q8=
-github.com/gethinode/mod-fontawesome/v6 v6.0.1/go.mod h1:Pz24mpGcg4FvGHhwPiuEZzOzISeOcoaQROhI6xLW2bU=
+github.com/gethinode/mod-fontawesome/v6 v6.0.2 h1:MxaHU7MZIh4pgxtoR6C/F0qiB5eSiySmRpTw9DGIOVs=
+github.com/gethinode/mod-fontawesome/v6 v6.0.2/go.mod h1:Zy+hjVhFDU52nkTIn9btbZ1PWy2n203zKHiPG9RVSL0=
 github.com/gethinode/mod-utils/v6 v6.5.0 h1:NdeITAfjt2ah9OHt0Nuu6F+STlC0bO9oHaFl8Agi2rk=
 github.com/gethinode/mod-utils/v6 v6.5.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/twbs/icons v1.13.1 h1:6bmNXvoeIbvjFWjfbjXg5JGbelLD1haIsMaEIzE9UZI=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gethinode/mod-bootstrap v1.3.7 // indirect
 	github.com/gethinode/mod-csp v1.0.12 // indirect
 	github.com/gethinode/mod-flexsearch/v5 v5.0.2 // indirect
-	github.com/gethinode/mod-fontawesome/v6 v6.0.1 // indirect
+	github.com/gethinode/mod-fontawesome/v6 v6.0.2 // indirect
 	github.com/gethinode/mod-google-analytics/v2 v2.0.4 // indirect
 	github.com/gethinode/mod-katex v1.1.6 // indirect
 	github.com/gethinode/mod-leaflet/v3 v3.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/gethinode/mod-fontawesome/v6 v6.0.0 h1:PrfiMfVEAM5Lpnkp+sXOtOdRSOe3l5
 github.com/gethinode/mod-fontawesome/v6 v6.0.0/go.mod h1:ayMslv2xpC5cjxUVTkIlFBbOd1LM5ezIr0OSOr6q8Gk=
 github.com/gethinode/mod-fontawesome/v6 v6.0.1 h1:Wq51kwbtlZYjLQdSbLjn1Qjf4ZkmGIbYrwxlO2vt9Q8=
 github.com/gethinode/mod-fontawesome/v6 v6.0.1/go.mod h1:Pz24mpGcg4FvGHhwPiuEZzOzISeOcoaQROhI6xLW2bU=
+github.com/gethinode/mod-fontawesome/v6 v6.0.2 h1:MxaHU7MZIh4pgxtoR6C/F0qiB5eSiySmRpTw9DGIOVs=
+github.com/gethinode/mod-fontawesome/v6 v6.0.2/go.mod h1:Zy+hjVhFDU52nkTIn9btbZ1PWy2n203zKHiPG9RVSL0=
 github.com/gethinode/mod-google-analytics/v2 v2.0.0 h1:Vor4j56qtpjtKY9r5QLeN5CBxuf8YKP3+XvQKEkayrM=
 github.com/gethinode/mod-google-analytics/v2 v2.0.0/go.mod h1:y4ZlacA8FSXjmvn9P8cZshOrBB5Wc+3p0DKSehkk+8E=
 github.com/gethinode/mod-google-analytics/v2 v2.0.1 h1:WNI8e06Bl1pLYrt1Adwuk4KtU9uVrJmO+KZxggIcI0M=


### PR DESCRIPTION
## Summary

Bumps mod-fontawesome to [v6.0.2](https://github.com/gethinode/mod-fontawesome/releases/tag/v6.0.2), which sorts the SVG symbol sprite (gethinode/mod-fontawesome#335).

Icons register in the sprite in first-use order, which races across pages when the first use sits inside a cached partial (`partialCached` executes on whichever page renders it first). Two builds of an unchanged site could therefore emit byte-different sprites on many pages, making byte-level build comparison unreliable — something we want as a regression gate for upcoming build-performance work.

## Verification

Two consecutive `hugo --gc --minify -s exampleSite` builds with v6.0.2 are fully byte-identical (806 files, zero diffs). Symbol sets per page are unchanged — order-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)