### PR TITLE
fix: read breakpoint via cached GetBreakpoint partial instead of page Scratch (render-once D3)

### DIFF
--- a/layouts/_partials/assets/breadcrumb.html
+++ b/layouts/_partials/assets/breadcrumb.html
@@ -30,7 +30,7 @@
 {{ end }}
 
 {{/* Initialize local arguments */}}
-{{- $breakpoint := $args.page.Scratch.Get "breakpoint" -}}
+{{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
 {{- $breadcrumbBack := partial "utilities/GetThemeIcon.html" (dict "id" "breadcrumbBack" "default" "fas angle-left") -}}
 
 {{/* Include breadcrumb items that have both a title and address */}}

--- a/layouts/_partials/assets/links.html
+++ b/layouts/_partials/assets/links.html
@@ -20,7 +20,7 @@
 {{ end }}
 
 {{/* Initialize global arguments */}}
-{{- $breakpoint := page.Scratch.Get "breakpoint" -}}
+{{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
 {{- $padding := partial "utilities/GetPadding.html" -}}
 
 {{- define "_partials/links-content.html" -}}

--- a/layouts/_partials/page/taxonomy-tag.html
+++ b/layouts/_partials/page/taxonomy-tag.html
@@ -1,4 +1,4 @@
-{{- $breakpoint := $.Scratch.Get "breakpoint" -}}
+{{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
 {{ $dateFormat := default "Jan 2" (index .Site.Params "date_format") }}
 {{ $.Scratch.Set "lastYear" ""}}
 

--- a/layouts/docs/all.html
+++ b/layouts/docs/all.html
@@ -2,7 +2,7 @@
 {{/* Inserts auto-generated sidebar with section navigation */}}
 {{/* Renders blocks inside main body */}}
 {{ define "main" -}}
-    {{- $breakpoint := $.Scratch.Get "breakpoint" -}}
+    {{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
     {{- $padding := partial "utilities/GetPadding.html" -}}
     
     {{/* Auto-generated sidebar for docs */}}

--- a/layouts/docs/header.html
+++ b/layouts/docs/header.html
@@ -6,7 +6,7 @@
 {{- $sharing := .Scratch.Get "sharing" -}}
 
 {{/* Initialize local variables */}}
-{{- $breakpoint := .Scratch.Get "breakpoint" -}}
+{{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
 {{ $title := .Title }}
 {{ if and .Site.Params.main.titleCase (not .Params.exact) }}{{ $title = title $title }}{{ end }}
 

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -6,7 +6,7 @@
 {{- $sharing := .Scratch.Get "sharing" -}}
 
 {{/* Initialize local variables */}}
-{{- $breakpoint := .Scratch.Get "breakpoint" -}}
+{{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
 {{ $title := .Title }}
 {{ if and .Site.Params.main.titleCase (not .Params.exact) }}{{ $title = title $title }}{{ end }}
 

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -1,5 +1,5 @@
 {{ define "main" -}}
-    {{- $breakpoint := $.Scratch.Get "breakpoint" -}}
+    {{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
     {{- $padding := partial "utilities/GetPadding.html" -}}
     {{- $content := partial "utilities/ProcessContent" (dict "page" .Page "raw" .RawContent) }}
 

--- a/layouts/minimal/header.html
+++ b/layouts/minimal/header.html
@@ -5,7 +5,7 @@
 {{- $padding := partial "utilities/GetPadding.html" -}}
 
 {{/* Initialize local variables */}}
-{{- $breakpoint := .Scratch.Get "breakpoint" -}}
+{{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
 {{ $title := .Title }}
 {{ if and .Site.Params.main.titleCase (not .Params.exact) }}{{ $title = title $title }}{{ end }}
 

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -1,5 +1,5 @@
 {{ define "main" -}}
-    {{- $breakpoint := $.Scratch.Get "breakpoint" -}}
+    {{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
     {{- $padding := partial "utilities/GetPadding.html" -}}
     {{- $sidebar := partial "page/sidebar" . -}}
 

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
     {{- $page := . -}}
     {{- $layout := $page.Params.layout -}}
-    {{- $breakpoint := $.Scratch.Get "breakpoint" -}}
+    {{- $breakpoint := partialCached "utilities/GetBreakpoint.html" site -}}
     {{- $padding := partial "utilities/GetPadding.html" -}}
     {{- $pageTitle := .Page.Title }}
     {{ if and site.Params.main.titleCase (not .Page.Params.exact) }}{{ $pageTitle = title $pageTitle }}{{ end }}


### PR DESCRIPTION
## Render-once program — slice D3 (HELD for maintainer review)

Part of the Hinode render-once implementation program (design:
gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md`, §4.1/§6-D3).

### Changes
All 10 readers of `Scratch.Get "breakpoint"` now call
`partialCached "utilities/GetBreakpoint.html" site` directly (`single`, `list`, `tags/list`,
`header`, `docs/header`, `docs/all`, `minimal/header`, `page/taxonomy-tag`, `assets/links`,
`assets/breadcrumb`). GetBreakpoint is a pure function of `site.Params.main.breakpoint`, so the
cached call is context-free; cache behavior is identical (one entry per language). The seed at
`baseof.html:24` stays until D9 (mod-blocks ≤ current release still reads the Scratch key).

### Gate evidence (byte-diff, exampleSite @ 50b5612b, hugo v0.164.0)
- Stock ×2 + candidate ×2: 0 ERROR, 98/26/24 pages, WARN set byte-identical.
- Run-vs-run: clean on both sides (allowlisted RSS files only).
- Candidate-vs-stock: allowlist **plus one deliberate diff**, accepted by the maintainer
  (2026-07-16): `en/docs/components/breadcrumb/index.html` — two attribute values change from the
  malformed `d--none`/`d--block` (stock deterministically hits the documented breakpoint-Scratch
  bug when the breadcrumb demo renders a foreign page via `.Site.GetPage`) to the correct
  `d-sm-none`/`d-sm-block`. This PR fixes that bug at the source; `grep -rl 'd--none'` over the
  candidate output is empty.
- `pnpm test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)