### PR TITLE
fix: thread owning page and embed flag into bookshop content blocks (render-once D4)

### DIFF
--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6 // indirect
 	github.com/cloudcannon/bookshop/hugo/v3 v3.18.5 // indirect
-	github.com/gethinode/mod-blocks/v2 v2.1.4 // indirect
 	github.com/gethinode/mod-bootstrap-icons/v2 v2.0.1 // indirect
 	github.com/gethinode/mod-cookieyes/v2 v2.2.6 // indirect
 	github.com/gethinode/mod-docs v1.15.2 // indirect

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -2,8 +2,6 @@ github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6 h1:slcJCZ
 github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/cloudcannon/bookshop/hugo/v3 v3.18.5 h1:AKWzUQpWcBSbJgHQ/5cfPQtGX40bn8vbHBGk4rlHEGE=
 github.com/cloudcannon/bookshop/hugo/v3 v3.18.5/go.mod h1:s7mIonDhtsLcn10ZKuVXyqd6BDHI8vT1WQhZw8rPfY8=
-github.com/gethinode/mod-blocks/v2 v2.1.4 h1:HV6S8xDQRZ3RaRdpXOPzyULIp53XQZJHWURLGTMBy1Y=
-github.com/gethinode/mod-blocks/v2 v2.1.4/go.mod h1:z+0Rg+I0naJf7VOy9dDuo8FX1dB5bPuMmbWT1QmBFhg=
 github.com/gethinode/mod-bootstrap-icons/v2 v2.0.1 h1:shq4Gb48U3h9xYUpq+FSHWz/eu1azJ5bMkja6wPmCpM=
 github.com/gethinode/mod-bootstrap-icons/v2 v2.0.1/go.mod h1:oRJGGe/EP/DRynePDHtaiC9ONR58+Jbm1c46Cgv0+jw=
 github.com/gethinode/mod-cookieyes/v2 v2.2.6 h1:/DQm8OYpms0On8wuosQER47TplVu/3z7MZHwbBKXCAg=

--- a/exampleSite/hinode.work.sum
+++ b/exampleSite/hinode.work.sum
@@ -16,3 +16,4 @@ github.com/gethinode/mod-fontawesome/v3 v3.1.3 h1:xlwmdgulIV/IMj5I1/fH4tPM1/AU0O
 github.com/gethinode/mod-fontawesome/v3 v3.1.3/go.mod h1:+E6jSVNv7h6oXw4Wm1XRq8HBEB2WrvxCPkp6u4vY5xo=
 github.com/gethinode/mod-utils/v4 v4.12.0 h1:5sSfYIxZCeQbXLoZdS//rl6thwLwtXuvM0ujaWKyPmc=
 github.com/gethinode/mod-utils/v4 v4.12.0/go.mod h1:bYmvRdAo4ICy5MpSGafDvO4p5bTDpsDKFCPL3bH0mN4=
+github.com/gethinode/mod-utils/v6 v6.5.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6 // indirect
 	github.com/airbnb/lottie-web v5.13.0+incompatible // indirect
+	github.com/gethinode/mod-blocks/v2 v2.2.0 // indirect
 	github.com/gethinode/mod-bootstrap v1.3.7 // indirect
 	github.com/gethinode/mod-csp v1.0.12 // indirect
 	github.com/gethinode/mod-flexsearch/v5 v5.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6 h1:slcJCZ
 github.com/FortAwesome/Font-Awesome v0.0.0-20260625220317-70fb2dd154b6/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/airbnb/lottie-web v5.13.0+incompatible h1:plBV5Uq/F1kK0EC61Hr0cBGReI9OgUfd/pp0baoDX8o=
 github.com/airbnb/lottie-web v5.13.0+incompatible/go.mod h1:nTss557UK9FGnp8QYlCMO29tjUHwbdAHG/DprbGfHGE=
+github.com/gethinode/mod-blocks/v2 v2.2.0 h1:sIRH7R7MYvqVECByJEuopVgzUCOa+iOEYOFCIouo5A0=
+github.com/gethinode/mod-blocks/v2 v2.2.0/go.mod h1:z+0Rg+I0naJf7VOy9dDuo8FX1dB5bPuMmbWT1QmBFhg=
 github.com/gethinode/mod-bootstrap v1.3.7 h1:rbjOg//q7dbsM+TkDQLsyk9LKv93D1RUjtcSkvV55UU=
 github.com/gethinode/mod-bootstrap v1.3.7/go.mod h1:CxrYCFzKtBMz3YWG5i/d5jHKCgvUo60NFcCmz2mxCjQ=
 github.com/gethinode/mod-csp v1.0.12 h1:6CaIH3IBn92lcwMFdYPmmWsPKq+VZ6n9Po8FI26jLJc=

--- a/layouts/_shortcodes/example-bookshop.html
+++ b/layouts/_shortcodes/example-bookshop.html
@@ -61,7 +61,7 @@
         {{ $lang = (trim (index (split $content "\n") 2) "\x60") | default "yml" }}
         {{ $content = index (index $inputRE 0) 2 }}
         {{ $data = index (unmarshal $content) 0 }}
-        {{ $data = merge $data (dict "section_class" $sectionClass) }}
+        {{ $data = merge $data (dict "section_class" $sectionClass "_page" .Page) }}
         {{ $component_name := (index $data "_bookshop_name") }}
         {{ if not $component_name }}
             {{ errorf "Expected '_bookshop_name': %s" .Position -}}

--- a/layouts/docs/all.html
+++ b/layouts/docs/all.html
@@ -23,8 +23,9 @@
             <div class="col-12 col-{{ $breakpoint.current }}-9 col-{{ $breakpoint.next }}-8 mb-5">
                 {{/* Render the defined content blocks, using the default articles element as fallback for list pages */}}
                 {{ if .Params.content_blocks }}
+                    {{/* The scratch value below is deprecated, kept for module version skew */}}
                     {{- $.Scratch.Set "blocks_embed" true -}}
-                    {{- partial "page/blocks.html" . -}}
+                    {{- partial "page/blocks.html" (dict "page" . "embed" true) -}}
                 {{ else if eq .Kind "section" }}
                     {{ $.Scratch.Set "articlesParams" (dict
                         "sort"         "weight"


### PR DESCRIPTION
## Render-once program — slice D4, hinode side (HELD for maintainer review)

Part of the Hinode render-once implementation program (design:
gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md` §4.2/§6-D4).
Companion to gethinode/mod-blocks#163 (merged, released as v2.2.0).

### Changes
- `_shortcodes/example-bookshop.html` — merges `"_page" .Page` into the component dict, so
  bookshop components rendered from page content use the owning page instead of the ambient
  global (which resolves to the *triggering* page in foreign-context `.Content` renders).
- `layouts/docs/all.html` — passes `(dict "page" . "embed" true)` to `page/blocks.html`
  (mod-blocks ≥2.2.0 signature); the `blocks_embed` Scratch seed stays for one release
  (removed in D9).
- `go.mod` — mod-blocks v2.1.4 → v2.2.0 (required: the legacy `page/blocks.html` cannot accept
  the dict signature). No other version movement (MVS verified).

### Expected diffs (maintainer-accepted 2026-07-16) — all deterministic render-once fixes
Candidate-vs-stock differs in 83 files, classified exhaustively:
1. **82 files change only their EN script-bundle reference** (hash/SRI): the FlexSearch index now
   records the owning page's breadcrumb in the `docs/blocks/hero` examples instead of the 404
   page's (the 404's card list used to win the `.Content` race), which changes the embedded
   search-index bundle bytes → new fingerprint in every EN page.
   Included: `en/404.html` additionally **stops loading a stray `simple-datatables` script** that
   was registered on it by a foreign-context render (class-c3 fix).
2. **1 substantive file**: `en/docs/blocks/list/index.html` — the documented UID pair shift
   (`table-filter-UID-1` → `UID-2`, class-c6; ids stay internally consistent).
Run-vs-run is clean on both sides (allowlisted RSS files only); 0 ERROR; 98/26/24 pages; WARN
set unchanged; no latent AddModule warnings. Re-verified by the program driver against the
released v2.2.0 (byte-identical to the replacement-based gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)