### PR TITLE
feat: render the docs sidebar once per section, version, and language (render-once E)

### DIFF
--- a/assets/js/critical/js-detect.js
+++ b/assets/js/critical/js-detect.js
@@ -1,0 +1,7 @@
+// Swap the `no-js` marker class on the root element for `js` as early as possible, so
+// stylesheets can key no-JS fallbacks (such as the sidebar collapse trail) off `no-js`.
+(function () {
+  var el = document.documentElement
+  el.classList.remove('no-js')
+  el.classList.add('js')
+}())

--- a/assets/js/critical/sidebar-active.js
+++ b/assets/js/critical/sidebar-active.js
@@ -1,0 +1,97 @@
+// Client-side sidebar active-item highlighting. The sidebar HTML is rendered once per
+// (section, version, language, variant) and cached, so the server no longer emits per-page
+// `active` classes or an expanded collapse trail; this script applies them from the current
+// location. It runs in the critical bundle so the highlight lands before first paint.
+(function () {
+  'use strict'
+
+  function normalize (path) {
+    try { path = decodeURI(path) } catch { /* keep the raw path */ }
+    if (path.length > 1) path = path.replace(/\/+$/, '')
+    return path || '/'
+  }
+
+  function findBestMatch (nav, pathname) {
+    var best = null
+    var bestLength = -1
+    var bestExact = false
+    nav.querySelectorAll('a[href]').forEach(function (link) {
+      var href = link.getAttribute('href')
+      if (!href || href.charAt(0) === '#') return
+      var url
+      try { url = new URL(href, window.location.origin) } catch { return }
+      if (url.origin !== window.location.origin) return
+      var path = normalize(url.pathname)
+      if (path === pathname) {
+        if (!bestExact) {
+          best = link
+          bestLength = path.length
+          bestExact = true
+        }
+      } else if (!bestExact && link.getAttribute('data-sidebar-match') === 'prefix') {
+        var prefix = path === '/' ? '/' : path + '/'
+        if (pathname.indexOf(prefix) === 0 && path.length > bestLength) {
+          best = link
+          bestLength = path.length
+        }
+      }
+    })
+    return { link: best, exact: bestExact }
+  }
+
+  function initNav (nav, pathname) {
+    var match = findBestMatch(nav, pathname)
+    var link = match.link
+    if (!link) return
+
+    nav.classList.add('sidebar-no-transition')
+    link.classList.add('active')
+    link.setAttribute('aria-current', match.exact ? 'page' : 'true')
+
+    // Expand the collapse trail: the matched group's own collapse (when the link is a group
+    // title) plus every collapse ancestor within this nav instance.
+    var own = null
+    var group = link.closest('.sidebar-item-group')
+    if (group && group.parentElement) {
+      own = group.parentElement.querySelector(':scope > .collapse')
+    }
+    var trail = own ? [own] : []
+    var ancestor = link.closest('.collapse')
+    while (ancestor && nav.contains(ancestor)) {
+      trail.push(ancestor)
+      ancestor = ancestor.parentElement && ancestor.parentElement.closest('.collapse')
+    }
+    trail.forEach(function (el) {
+      el.classList.add('show')
+      if (el.id) {
+        nav.querySelectorAll('[data-bs-target="#' + el.id + '"]').forEach(function (toggle) {
+          toggle.setAttribute('aria-expanded', 'true')
+        })
+      }
+    })
+    nav.offsetHeight // force reflow before re-enabling transitions
+    nav.classList.remove('sidebar-no-transition')
+
+    // Clicking the current group's title toggles its collapse instead of re-navigating.
+    if (own && match.exact) {
+      link.addEventListener('click', function (event) {
+        if (typeof bootstrap === 'undefined' || !bootstrap.Collapse) return
+        event.preventDefault()
+        bootstrap.Collapse.getOrCreateInstance(own).toggle()
+      })
+    }
+  }
+
+  function init () {
+    var pathname = normalize(window.location.pathname)
+    document.querySelectorAll('[data-sidebar-nav]').forEach(function (nav) {
+      initNav(nav, pathname)
+    })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init)
+  } else {
+    init()
+  }
+}())

--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -198,6 +198,14 @@ html.sidebar-pre-collapsed .sidebar-collapsible .sidebar-brand {
                     }
 }
 
+// No-JS fallback: the collapse trail and active highlight are applied client-side by
+// sidebar-active.js, and Bootstrap's collapse toggles require JavaScript. Without JavaScript
+// (the `no-js` class set in baseof.html is swapped for `js` by critical/js-detect.js) render
+// every sidebar group expanded instead.
+.no-js .sidebar .collapse {
+    display: block;
+}
+
 // Collapsible sidebar
 .sidebar-no-transition,
 .sidebar-no-transition * {

--- a/data/structures/link.yml
+++ b/data/structures/link.yml
@@ -30,6 +30,16 @@ arguments:
     optional: true
     comment: Skip internal link validation (use for dynamic content).
     release: v2.0.0
+  icon-mode:
+    type: string
+    optional: true
+    group: partial
+    release: v3.3.0
+    comment: >-
+      Per-call rendering mode of the external-link cue icon (one of `symbols`,
+      `svg`, or `webfonts`), passed through to the icon partial. Cached
+      contexts such as the sidebar pass `svg` to avoid per-page sprite
+      registration; defaults to the globally configured icon mode.
   # deprecated arguments
   destination:
     type: string

--- a/data/structures/sidebar.yml
+++ b/data/structures/sidebar.yml
@@ -20,6 +20,24 @@ arguments:
     comment: >-
       Version of the sidebar navigation, used to define the base URL of
       generated links, together with the page's section.
+  baseURL:
+    type: string
+    optional: true
+    group: partial
+    release: v3.3.0
+    comment: >-
+      Base URL of the site for the current language, used to resolve relative
+      menu links. Pass it explicitly (see `page/sidebar-cached.html`) so the
+      renderer performs no per-page Scratch reads; defaults to `/`.
+  filename:
+    type: string
+    optional: true
+    group: partial
+    release: v3.3.0
+    comment: >-
+      Path of the data file that defines the sidebar menu, used in error
+      messages only. Passed explicitly by `page/sidebar-cached.html` so the
+      renderer performs no per-page Scratch reads.
   auto-generate:
     type: bool
     optional: true

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,7 @@ export default [
     }
   },
   {
-    files: ['assets/js/sidebar-toggle.js'],
+    files: ['assets/js/sidebar-toggle.js', 'assets/js/critical/sidebar-active.js'],
     languageOptions: {
       globals: {
         bootstrap: 'readonly'

--- a/exampleSite/hinode.work.sum
+++ b/exampleSite/hinode.work.sum
@@ -1,3 +1,5 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0 h1:4+bB2ojsMTsQroHtQr1FWy2gxFzpBn5hISldeRfxF+o=
+github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/cloudcannon/bookshop/hugo/v3 v3.17.1 h1:weTVWBamjQHMIp/oYTFsPwRzzhWrZA6JO43QnxI1kxw=
 github.com/cloudcannon/bookshop/hugo/v3 v3.17.1/go.mod h1:s7mIonDhtsLcn10ZKuVXyqd6BDHI8vT1WQhZw8rPfY8=
 github.com/cloudcannon/bookshop/hugo/v3 v3.18.2 h1:j3XUvvuCv/7SfGKzd7gzb3WEgs1DurqTRDe7gdMAAvU=
@@ -14,6 +16,8 @@ github.com/gethinode/mod-fontawesome/v2 v2.1.2 h1:v1aHhbLLwe/05zRHnx9qGqh6b3toDz
 github.com/gethinode/mod-fontawesome/v2 v2.1.2/go.mod h1:zukv88wXqquEvTJJ9mWWk8Ia+9INnA41wYqusf2RcHA=
 github.com/gethinode/mod-fontawesome/v3 v3.1.3 h1:xlwmdgulIV/IMj5I1/fH4tPM1/AU0OYZ4vepQiJbOYA=
 github.com/gethinode/mod-fontawesome/v3 v3.1.3/go.mod h1:+E6jSVNv7h6oXw4Wm1XRq8HBEB2WrvxCPkp6u4vY5xo=
+github.com/gethinode/mod-fontawesome/v6 v6.1.0 h1:hvhBAHuICZYAiQdmcd+qtLRoiJAIgU7/5sEbs1GoVW4=
+github.com/gethinode/mod-fontawesome/v6 v6.1.0/go.mod h1:875OBk5te+KBJmr0PdSkFcduYnsKCuHWfcaqChh9NGo=
 github.com/gethinode/mod-utils/v4 v4.12.0 h1:5sSfYIxZCeQbXLoZdS//rl6thwLwtXuvM0ujaWKyPmc=
 github.com/gethinode/mod-utils/v4 v4.12.0/go.mod h1:bYmvRdAo4ICy5MpSGafDvO4p5bTDpsDKFCPL3bH0mN4=
 github.com/gethinode/mod-utils/v6 v6.5.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=

--- a/layouts/_partials/assets/link.html
+++ b/layouts/_partials/assets/link.html
@@ -79,7 +79,9 @@
             {{- end -}}
 
             {{- if $cue -}}
-                {{- $suffix := partial "assets/icon.html" (dict "page" $args.page "icon" $externalLink "class" "fa-2xs" "spacing" false) -}}
+                {{- $iconArgs := dict "page" $args.page "icon" $externalLink "class" "fa-2xs" "spacing" false -}}
+                {{- with $args.iconMode }}{{ $iconArgs = merge $iconArgs (dict "mode" .) }}{{ end -}}
+                {{- $suffix := partial "assets/icon.html" $iconArgs -}}
                 {{- $text = printf "%s&nbsp;%s" $text $suffix | safeHTML -}}
             {{- end -}}
         {{- else -}}

--- a/layouts/_partials/assets/sidebar.html
+++ b/layouts/_partials/assets/sidebar.html
@@ -51,20 +51,19 @@
         {{- $href = partial "utilities/URLJoin.html" (dict "base" $baseURL "path" $href) -}}
     {{- end -}}
     {{- if and $href (not (hasSuffix $href "/")) -}}{{- $href = printf "%s/" $href -}}{{- end -}}
-    {{- $active := and $href (strings.HasPrefix $page.RelPermalink $href) -}}
     {{- $groupTitle := $group.title -}}
     {{- if and site.Params.main.titleCase (not $page.Params.exact) -}}
         {{- $groupTitle = title $groupTitle -}}
     {{- end -}}
     <li class="mb-1">
-        <a class="sidebar-item text-decoration-none rounded w-100{{ if $active }} active{{ end }}"
+        <a class="sidebar-item text-decoration-none rounded w-100"
            {{- if $collapsible }} data-sidebar-label="{{ $groupTitle }}"{{ end }}
-           {{ with $href }}href="{{ . }}"{{ end }}>
+           {{ with $href }}href="{{ . }}" data-sidebar-match="prefix"{{ end }}>
             {{- with $pre -}}
                 {{- if hasPrefix . "<i" -}}
                     {{ . | safeHTML }}
                 {{- else -}}
-                    {{ partial "assets/icon.html" (dict "page" $page "icon" (string .) "class" "fa-fw me-1" "spacing" false) }}
+                    {{ partial "assets/icon.html" (dict "icon" (string .) "class" "fa-fw me-1" "spacing" false "mode" "svg") }}
                 {{- end -}}
             {{- end -}}
             {{- if $collapsible -}}
@@ -84,6 +83,7 @@
     {{- $group := .group -}}
     {{- $data := .menu -}}
     {{- $pre := $group.pre -}}
+    {{- $filename := .filename -}}
 
     {{- $doc_slug := partial "utilities/URLJoin.html" (dict "base" $baseURL "path" ($group.title | urlize)) -}}
     {{- $href := or $group.link $doc_slug -}}
@@ -96,9 +96,7 @@
     {{- end -}}
     {{ $ref := partial "utilities/GetPage.html" (dict "url" $href "page" $page) }}
     {{ if eq $group.link "#" }}{{ $href = $doc_slug }}{{ end }}
-    {{- $collapsed := strings.HasPrefix $page.RelPermalink $href -}}
     {{ if not (hasSuffix $href "/") }}{{ $href = printf "%s/" $href }}{{ end }}
-    {{- $current := eq $href $page.RelPermalink }}
 
     <li class="mb-1">
         <div class="d-flex w-100 p-0 sidebar-item-group">
@@ -108,7 +106,7 @@
 
                 {{ $dest := $href }}
                 {{ $target := "" }}
-                {{ if or $current (not $ref) }}
+                {{ if not $ref }}
                     {{ $dest = "" }}
                 {{ end }}
                 <a {{ if gt $level 1 }}class="small" {{ end }}{{ with $dest }} href="{{ . }}"{{ else }}
@@ -119,7 +117,7 @@
                         {{- if hasPrefix . "<i" -}}
                             {{ . | safeHTML }}
                         {{- else -}}
-                            {{ partial "assets/icon.html" (dict "page" $page "icon" (string .) "class" "fa-fw me-1" "spacing" false) }}
+                            {{ partial "assets/icon.html" (dict "icon" (string .) "class" "fa-fw me-1" "spacing" false "mode" "svg") }}
                         {{- end -}}
                     {{- end -}}
                     {{- $groupTitle -}}
@@ -130,11 +128,11 @@
                 class="btn btn-toggle-group d-inline-flex align-items-center rounded border-0 collapsed"
                 data-bs-toggle="collapse"
                 data-bs-target="#sidebar-collapse-{{ $index }}-{{ $level }}"
-                aria-expanded="{{ if $collapsed }}true{{ else }}false{{ end }}"
+                aria-expanded="false"
             >
             </button>
         </div>
-        <div class="collapse {{ if $collapsed }}show{{ end }}" id="sidebar-collapse-{{ $index }}-{{ $level }}">
+        <div class="collapse" id="sidebar-collapse-{{ $index }}-{{ $level }}">
             <ul class="btn-toggle-nav list-unstyled fw-normal {{ if eq $level 0}} pb-1 {{ end }}ps-3">
                 {{- range $childIndex, $item := $group.pages -}}
                     {{- if $item.pages -}}
@@ -142,13 +140,14 @@
                              nested collapse element IDs stay unique across
                              sibling branches at the same depth. */}}
                         {{ partial "inline/sidebar/group.html" (dict
-                            "page"    $page
-                            "index"   (printf "%v-%v" $index $childIndex)
-                            "level"   (add $level 1)
-                            "baseURL" $href
-                            "group"   $item
-                            "menu"    $data
-                            "pre"     $item.pre
+                            "page"     $page
+                            "index"    (printf "%v-%v" $index $childIndex)
+                            "level"    (add $level 1)
+                            "baseURL"  $href
+                            "group"    $item
+                            "menu"     $data
+                            "pre"      $item.pre
+                            "filename" $filename
                             )
                         }}
                     {{- else -}}
@@ -160,6 +159,7 @@
                             "href"         $item.link
                             "menu"         $data
                             "pre"          $item.pre
+                            "filename"     $filename
                             )
                         }}
                     {{ end -}}
@@ -178,6 +178,7 @@
     {{- $pre         := .pre -}}
     {{- $collapsible := .collapsible | default false -}}
     {{- $prefixMatch := .prefixMatch | default false -}}
+    {{- $filename    := .filename -}}
     {{- if and site.Params.main.titleCase (not $page.Params.exact) -}}
         {{- $title = title $title -}}
     {{- end -}}
@@ -187,7 +188,7 @@
     {{- end -}}
     {{- $itemText := $titleText -}}
     {{- with $pre -}}
-        {{- $iconHTML := partial "assets/icon.html" (dict "page" $page "icon" (string .) "class" "fa-fw me-1" "spacing" false) -}}
+        {{- $iconHTML := partial "assets/icon.html" (dict "icon" (string .) "class" "fa-fw me-1" "spacing" false "mode" "svg") -}}
         {{- $itemText = printf "%s%s" (string $iconHTML) $titleText -}}
     {{- end -}}
     {{ $href := "" }}
@@ -207,23 +208,23 @@
         {{- $href = partial "utilities/URLJoin.html" (dict "base" $baseURL "path" ($title | urlize)) -}}
         {{ if not (hasSuffix $href "/") }}{{ $href = printf "%s/" $href }}{{ end }}
     {{ end }}
-    {{- $active := or (eq (strings.TrimSuffix "/" $page.RelPermalink) (strings.TrimSuffix "/" $href)) (and $prefixMatch $href (strings.HasPrefix $page.RelPermalink $href)) -}}
-
     {{ if eq $level 0}}
         <li class="mt-1 mb-1"></li>
         <li>
             <ul class="btn-toggle-nav list-unstyled pb-1">
                 <li>
                     {{ $class := "sidebar-item text-decoration-none rounded w-100" }}
-                    {{ if $active }}{{ $class = printf "%s active" $class }}{{ end }}
-                    {{ $link := partial "assets/link.html" (dict "href" $href "text" $itemText "class" $class "page" $page "exact" true) }}
+                    {{ $link := partial "assets/link.html" (dict "href" $href "text" $itemText "class" $class "page" $page "exact" true "icon-mode" "svg") }}
                     {{- if and $collapsible $title $link -}}
                         {{- $link = $link | replaceRE `(<a)\s` (printf `${1} data-sidebar-label="%s" ` ($title | htmlEscape)) -}}
+                    {{- end -}}
+                    {{- if and $prefixMatch $link -}}
+                        {{- $link = $link | replaceRE `(<a)\s` `${1} data-sidebar-match="prefix" ` -}}
                     {{- end -}}
                     {{ if $link }}
                         {{ print $link | safeHTML }}
                     {{ else }}
-                        {{- errorf "partial [utilities/sidebar.html] - Invalid link in file: %s" ($page.Scratch.Get "sidebarFilename") -}}
+                        {{- errorf "partial [utilities/sidebar.html] - Invalid link in file: %s" $filename -}}
                     {{ end }}
                 </li>
             </ul>
@@ -231,12 +232,14 @@
     {{ else }}
         <li>
             {{ $class := "sidebar-item text-decoration-none rounded small w-100" }}
-            {{ if $active }}{{ $class = printf "%s active" $class }}{{ end }}
-            {{ $link := partial "assets/link.html" (dict "href" $href "text" $itemText "class" $class "page" $page "exact" true) }}
+            {{ $link := partial "assets/link.html" (dict "href" $href "text" $itemText "class" $class "page" $page "exact" true "icon-mode" "svg") }}
+            {{- if and $prefixMatch $link -}}
+                {{- $link = $link | replaceRE `(<a)\s` `${1} data-sidebar-match="prefix" ` -}}
+            {{- end -}}
             {{ if $link }}
                 {{ print $link | safeHTML }}
             {{ else }}
-                {{- errorf "partial [utilities/sidebar.html] - Invalid link in file: %s" ($page.Scratch.Get "sidebarFilename") -}}
+                {{- errorf "partial [utilities/sidebar.html] - Invalid link in file: %s" $filename -}}
             {{ end }}
         </li>
     {{ end }}
@@ -253,10 +256,11 @@
     {{- $hasSpacerItem := gt (len (where $args.menu "spacer" true)) 0 -}}
     {{- $sidebarId     := $section | urlize | default "sidebar" -}}
     <nav class="sidebar flex-shrink-0 ps-1{{ if ge $levelMin 2 }} sidebar-sub{{ end }}{{ if $collapsible }} sidebar-collapsible{{ end }}{{ if $hasSpacerItem }} sidebar-has-spacer{{ end }}"
+         data-sidebar-nav
          {{- if $collapsible }} data-storage-key="sidebar-collapsed"{{ end }}
          aria-label="{{ (strings.FirstUpper $section) }} navigation">
         {{- $level := 0 -}}
-        {{ $baseURL := $args.page.Scratch.Get "baseURL" | default "/" -}}
+        {{ $baseURL := $args.baseURL | default "/" -}}
         {{ $baseURL = partial "utilities/URLJoin.html" (dict "elements" (slice "/" (strings.TrimPrefix $baseURL (urls.JoinPath $section $args.version | relLangURL)))) }}
 
         {{- if and (le $levelMin 1) (eq $levelMax 1) -}}
@@ -295,7 +299,7 @@
             {{- if $collapsible -}}
             <div class="sidebar-toggle-container d-flex justify-content-end mb-2 pe-1">
                 <button class="btn btn-sm sidebar-toggle-btn p-1 border-0" aria-label="Toggle sidebar">
-                    {{- partial "assets/icon.html" (dict "page" $page "icon" $iconCollapse "class" "sidebar-icon-toggle") -}}
+                    {{- partial "assets/icon.html" (dict "icon" $iconCollapse "class" "sidebar-icon-toggle" "mode" "svg") -}}
                 </button>
             </div>
             {{- end -}}
@@ -328,6 +332,7 @@
                         "menu"        $args.menu
                         "pre"         $item.pre
                         "collapsible" $collapsible
+                        "filename"    $args.filename
                     ) }}
                 {{- end -}}
             {{- end -}}
@@ -346,6 +351,7 @@
                                 "pre"         .pre
                                 "collapsible" $collapsible
                                 "prefixMatch" true
+                                "filename"    $args.filename
                             ) }}
                         {{- end -}}
                         </ul>
@@ -362,15 +368,14 @@
                         {{- $avHref = partial "utilities/URLJoin.html" (dict "base" $baseURL "path" $avHref) -}}
                     {{- end -}}
                     {{- if and $avHref (not (hasSuffix $avHref "/")) -}}{{- $avHref = printf "%s/" $avHref -}}{{- end -}}
-                    {{- $avActive := eq (strings.TrimSuffix "/" $page.RelPermalink) (strings.TrimSuffix "/" $avHref) -}}
                     {{- $avTitle := .title -}}
                     {{- if and site.Params.main.titleCase (not $page.Params.exact) -}}{{- $avTitle = title $avTitle -}}{{- end -}}
                     <li class="d-flex align-items-center sidebar-secondary-row">
-                        <a class="sidebar-item text-decoration-none rounded flex-grow-1{{ if $avActive }} active{{ end }}"
+                        <a class="sidebar-item text-decoration-none rounded flex-grow-1"
                            {{- if $collapsible }} data-sidebar-label="{{ $avTitle }}"{{ end }}
                            href="{{ $avHref }}">
                             {{- with .pre -}}
-                                {{- partial "assets/icon.html" (dict "page" $page "icon" (string .) "class" "fa-fw me-1" "spacing" false) -}}
+                                {{- partial "assets/icon.html" (dict "icon" (string .) "class" "fa-fw me-1" "spacing" false "mode" "svg") -}}
                             {{- end -}}
                             {{- if $collapsible -}}
                                 <span class="sidebar-item-label ms-1">{{- $avTitle -}}</span>
@@ -385,7 +390,7 @@
                                 aria-expanded="false"
                                 aria-controls="sidebar-secondary-{{ $sidebarId }}"
                                 aria-label="{{ T "toggleSecondary" | default "Toggle more items" }}">
-                            {{- partial "assets/icon.html" (dict "page" $page "icon" $iconSecondary "class" "sidebar-secondary-icon fa-fw" "spacing" false) -}}
+                            {{- partial "assets/icon.html" (dict "icon" $iconSecondary "class" "sidebar-secondary-icon fa-fw" "spacing" false "mode" "svg") -}}
                         </button>
                         {{- end -}}
                     </li>
@@ -410,22 +415,24 @@
                 {{- range $index, $item := . -}}
                     {{- if $item.pages -}}
                         {{ partial "inline/sidebar/group.html" (dict
-                            "page"    $page
-                            "index"   $index
-                            "level"   1
-                            "baseURL" $baseURL
-                            "group"   $item
-                            "menu"    $activeGroup.pages
+                            "page"     $page
+                            "index"    $index
+                            "level"    1
+                            "baseURL"  $baseURL
+                            "group"    $item
+                            "menu"     $activeGroup.pages
+                            "filename" $args.filename
                         ) }}
                     {{- else -}}
                         {{ partial "inline/sidebar/item.html" (dict
-                            "page"    $page
-                            "level"   $level
-                            "baseURL" $baseURL
-                            "title"   $item.title
-                            "href"    $item.link
-                            "menu"    $activeGroup.pages
-                            "pre"     $item.pre
+                            "page"     $page
+                            "level"    $level
+                            "baseURL"  $baseURL
+                            "title"    $item.title
+                            "href"     $item.link
+                            "menu"     $activeGroup.pages
+                            "pre"      $item.pre
+                            "filename" $args.filename
                         ) }}
                     {{- end -}}
                 {{- end -}}
@@ -437,23 +444,25 @@
             {{- range $index, $item := $args.menu -}}
                 {{- if $item.pages }}
                     {{ partial "inline/sidebar/group.html" (dict
-                        "page"    $page
-                        "index"   $index
-                        "level"   (add $level 1)
-                        "baseURL" $baseURL
-                        "group"   $item
-                        "menu"    $args.menu
+                        "page"     $page
+                        "index"    $index
+                        "level"    (add $level 1)
+                        "baseURL"  $baseURL
+                        "group"    $item
+                        "menu"     $args.menu
+                        "filename" $args.filename
                         )
                     }}
                 {{- else }}
                     {{ partial "inline/sidebar/item.html" (dict
-                        "page"         $page
-                        "level"        $level
-                        "baseURL"      $baseURL
-                        "title"        $item.title
-                        "href"         $item.link
-                        "menu"         $args.menu
-                        "pre"          $item.pre
+                        "page"     $page
+                        "level"    $level
+                        "baseURL"  $baseURL
+                        "title"    $item.title
+                        "href"     $item.link
+                        "menu"     $args.menu
+                        "pre"      $item.pre
+                        "filename" $args.filename
                         )
                     }}
                 {{- end }}

--- a/layouts/_partials/page/sidebar-cached.html
+++ b/layouts/_partials/page/sidebar-cached.html
@@ -1,0 +1,51 @@
+{{/*
+    Copyright © 2022 - 2026 The Hinode Team / Mark Dumay. All rights reserved.
+    Use of this source code is governed by The MIT License (MIT) that can be found in the LICENSE file.
+    Visit gethinode.com/license for more details.
+*/}}
+
+{{/*
+    Uncached wrapper around the sidebar renderer that renders the sidebar tree once per
+    (section, version, language, variant) using partialCached. The rendered sidebar markup is
+    page-independent by contract: active-item highlighting and the expanded group trail are
+    applied client-side by assets/js/critical/sidebar-active.js. The wrapper:
+
+    1. computes the cache key tuple from the real page context,
+    2. canonicalizes the page context to the section root (the versioned section root when
+       applicable), so the cached output does not depend on which page happens to render first,
+    3. passes the base URL and the sidebar data filename as explicit arguments, so the cached
+       subtree performs no per-page Scratch reads,
+    4. keeps Mode B (level-min >= 2) uncached: that mode selects a subtree by the current
+       page's URL and is structurally page-dependent.
+
+    The raw renderer (assets/sidebar.html) stays cache-free and remains directly callable by
+    site overrides.
+*/}}
+
+{{- $args := . -}}
+{{- $page := $args.page -}}
+{{- $section := $page.Section -}}
+{{- $version := $args.version | default "" -}}
+{{- $lang := site.Language.Lang -}}
+{{- $levelMin := index $args "level-min" | default 0 -}}
+{{- $levelMax := index $args "level-max" | default 0 -}}
+{{- $collapsible := $args.collapsible | default false -}}
+{{- $autoGenerate := index $args "auto-generate" | default false -}}
+
+{{/* The base URL depends on site state only; the filename is set per menu by GetMenu */}}
+{{- $baseURL := partialCached "utilities/GetBaseURL.html" site -}}
+{{- $filename := $page.Scratch.Get "sidebarFilename" | default "" -}}
+
+{{- if ge $levelMin 2 -}}
+    {{/* Mode B renders a page-dependent subtree; call the renderer uncached */}}
+    {{- partial "assets/sidebar.html" (merge $args (dict "baseURL" $baseURL "filename" $filename)) -}}
+{{- else -}}
+    {{/* Canonicalize the page context to the (versioned) section root */}}
+    {{- $root := $page.FirstSection | default $page -}}
+    {{- with $version -}}
+        {{- with site.GetPage (path.Join $section .) }}{{ $root = . }}{{ end -}}
+    {{- end -}}
+    {{- $ctx := merge $args (dict "page" $root "baseURL" $baseURL "filename" $filename) -}}
+    {{- $variant := printf "%v-%v-%v-%v" $levelMin $levelMax $collapsible $autoGenerate -}}
+    {{- partialCached "assets/sidebar.html" $ctx $section $version $lang $variant -}}
+{{- end -}}

--- a/layouts/_partials/page/sidebar.html
+++ b/layouts/_partials/page/sidebar.html
@@ -1,5 +1,5 @@
 {{- $menu := .Scratch.Get "sidebar" -}}
 {{- $version := .Scratch.Get "version" -}}
 {{ if $menu }}
-    {{ partial "assets/sidebar.html" (dict "page" . "menu" $menu "version" $version) }}
+    {{ partial "page/sidebar-cached.html" (dict "page" . "menu" $menu "version" $version) }}
 {{ end -}}

--- a/layouts/docs/all.html
+++ b/layouts/docs/all.html
@@ -9,7 +9,7 @@
     {{- $menu := .Scratch.Get "sidebar" -}}
     {{- if not (reflect.IsSlice $menu) }}{{ $none := dict }}{{ $menu = $none.missing }}{{ end }}
     {{- $version := .Scratch.Get "version" -}}
-    {{- $sidebar := partial "assets/sidebar.html" (dict "page" . "menu" $menu "version" $version "auto-generate" true) -}}
+    {{- $sidebar := partial "page/sidebar-cached.html" (dict "page" . "menu" $menu "version" $version "auto-generate" true) -}}
 
     {{/* Render the offcanvas sidebar */}}
     {{- partial "page/sidebar-offcanvas.html" (dict "section" $.Section "raw" $sidebar) -}}


### PR DESCRIPTION
## Render-once program — chunk E (HELD for maintainer review)

Part of the Hinode render-once implementation program (design:
gethinode.com `docs/superpowers/specs/2026-07-15-sidebar-render-once-design.md`, maintainer
decisions §7-1..5). Reduces ~3,420 sidebar item renders to ~114 (one tree per
section/version/language/variant, ~30×) on the exampleSite docs.

### Changes
- **New `page/sidebar-cached.html`** — uncached wrapper: key tuple (section, version, lang,
  variant), context canonicalized to the (versioned) section root, `baseURL` via
  `partialCached utilities/GetBaseURL.html site` (mod-utils v6.6.0), `filename` as explicit
  arg; Mode B (`level-min ≥ 2`) stays uncached (§7-3). Raw `assets/sidebar.html` remains
  cache-free and override-friendly (§7-5). Both call sites switched.
- **`assets/sidebar.html` page-independent** — no server `active`, canonical collapsed state,
  current-group anchor swap removed (titles always link), `data-sidebar-nav` root hook,
  `data-sidebar-match="prefix"`, zero Scratch reads inside the cached subtree, internal icons
  render `mode="svg"` (mod-fontawesome v6.1.0 per-call arg, §7-4 — no sprite-registration
  hazard); `titleCase` `exact` now reads the section root (§7-1, documented behavior change).
- **New critical JS `sidebar-active.js`** — per-instance highlight (offcanvas + desktop),
  `aria-current` (a11y improvement), collapse-trail expansion, current-group click intercept
  (§7-2), no-transition init. Plus `js-detect.js` (`no-js`→`js`) and a `.no-js` SCSS fallback
  (all groups expanded without JS — strictly better than before). No inline styles/scripts (CSP).
- **go.mod** — mod-utils v6.5.1→v6.6.0, mod-fontawesome v6.0.2→v6.1.0 (drags the FA webfonts
  snapshot: 4 woff2 files, byte-verified upstream). `hugo mod tidy` pruned exampleSite pins
  (same pruning the daily mod-update applies).

### Gate evidence (deliberate-diff slice; own gate per design §1.5)
1. Within-key identity: all 60 docs sidebars byte-identical inside one key — independently
   re-verified by the driver: **1 distinct nav hash across 120 instances, 0 server `active`**.
2. Cached output byte-identical to the uncached intermediate (allowlist excepted).
3. Double-build determinism PASS (allowlist only); 0 ERROR; 98/26/24 pages; WARN set unchanged.
4. Candidate-vs-stock classified per line (132 diff lines): nav attrs / aria-expanded /
   collapse-show / active-removal / anchor-swap / bundle+CSS hashes / woff2 — zero unclassified.
5. Functional check (Chromium): highlight + trail on both copies, current-group click folds
   without navigating, `js` class swap, `.no-js` rule in compiled CSS.
6. `pnpm test` green (incl. eslint on the new JS).

### Notes for review
- Unlisted-subpage edge case in hand-written Mode C menus loses group pre-expansion (approved
  §2.2 contract).
- Mode A/B parity is code-level; the exampleSite exercises Mode C only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)