### PR TITLE
fix: thread the intrinsic page through content-reachable partials (render-once D5)

### DIFF
--- a/data/structures/card.yml
+++ b/data/structures/card.yml
@@ -3,6 +3,8 @@ comment: >-
   such as title, href, and thumbnail override the corresponding page attributes.
 icon: article
 arguments:
+  page:
+    optional: true
   title:
     optional: true
     preview: true

--- a/data/structures/download.yml
+++ b/data/structures/download.yml
@@ -1,6 +1,8 @@
 comment: Generates a download button or link.
 group: partial
 arguments:
+  page:
+    optional: true
   download:
   title:
   class:

--- a/data/structures/image-adapter.yml
+++ b/data/structures/image-adapter.yml
@@ -2,6 +2,8 @@ comment: >-
   Defines the interface to be implemented by a CDN image adapter.
 group: partial
 arguments:
+  page:
+    optional: true
   url-host:
     release: v1.0.0
   url-dir:

--- a/data/structures/image-set.yml
+++ b/data/structures/image-set.yml
@@ -3,6 +3,8 @@ comment: >-
   hook, including transform, format, and anchor options.
 group: partial
 arguments:
+  page:
+    optional: true
   src:
   img:
   absolute-url:

--- a/data/structures/section-title.yml
+++ b/data/structures/section-title.yml
@@ -3,6 +3,8 @@ comment: >-
   layout options.
 group: partial
 arguments:
+  page:
+    optional: true
   heading:
   links:
   color:

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -12,7 +12,10 @@ enableInlineShortcodes = true
 
 # prevent build failures when using Hugo's Instagram shortcode due to deprecated Instagram API.
 # See https://github.com/gohugoio/hugo/issues/7228#issuecomment-714490456
-ignoreErrors = ["error-remote-getjson", "warn-preview-restricted"]
+# the transitional 'warn-missing-page-argument' entry suppresses the fallback warning raised by
+# mod-blocks <= v2.1.4, which calls the section-title / image partials without a page argument;
+# remove it once the exampleSite picks up the mod-blocks release that threads the page explicitly.
+ignoreErrors = ["error-remote-getjson", "warn-preview-restricted", "warn-missing-page-argument"]
 timeout = "180s"
 
 languageCode = "en-us"

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -10,6 +10,5 @@ require (
 	github.com/gethinode/mod-cookieyes/v2 v2.2.6 // indirect
 	github.com/gethinode/mod-docs v1.15.2 // indirect
 	github.com/gethinode/mod-fontawesome/v6 v6.0.2 // indirect
-	github.com/gethinode/mod-utils/v6 v6.5.1 // indirect
 	github.com/twbs/icons v1.13.1 // indirect
 )

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -12,7 +12,5 @@ github.com/gethinode/mod-docs v1.15.2 h1:ZuOO/M5KyuUNGEoId+rManHG/L3WBboXG9L/ikS
 github.com/gethinode/mod-docs v1.15.2/go.mod h1:ru1w0fHqFocjDIMV0dm40OwhBw5k4UncCS8iO/1S5kI=
 github.com/gethinode/mod-fontawesome/v6 v6.0.2 h1:MxaHU7MZIh4pgxtoR6C/F0qiB5eSiySmRpTw9DGIOVs=
 github.com/gethinode/mod-fontawesome/v6 v6.0.2/go.mod h1:Zy+hjVhFDU52nkTIn9btbZ1PWy2n203zKHiPG9RVSL0=
-github.com/gethinode/mod-utils/v6 v6.5.1 h1:HhCN8Bc0cWxIY0ukjKP9O3jDbKg9F/YaTPO6vqjjk+I=
-github.com/gethinode/mod-utils/v6 v6.5.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/twbs/icons v1.13.1 h1:6bmNXvoeIbvjFWjfbjXg5JGbelLD1haIsMaEIzE9UZI=
 github.com/twbs/icons v1.13.1/go.mod h1:GnRlymgVWp5iVJCMa0Me5b6tFyGpVc2bSxPMRGIJmyA=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gethinode/mod-lottie/v3 v3.0.2 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.1 // indirect
 	github.com/gethinode/mod-simple-datatables/v4 v4.1.0 // indirect
-	github.com/gethinode/mod-utils/v6 v6.5.1 // indirect
+	github.com/gethinode/mod-utils/v6 v6.6.0 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/gethinode/mod-mermaid/v5 v5.0.1 h1:heGJ9i3rDXAh+qU8N0jSEPhVGOsQwxLpNm
 github.com/gethinode/mod-mermaid/v5 v5.0.1/go.mod h1:3M0XrI6Ginj5EIbXy1xOymv3KsfPuBhD07FEPz1SikI=
 github.com/gethinode/mod-simple-datatables/v4 v4.1.0 h1:AtEtLH9RoAEIpElg0k6UkVlHmiBc4Df3NCCUfBtmktU=
 github.com/gethinode/mod-simple-datatables/v4 v4.1.0/go.mod h1:jRHoX20bUiaVg7UtKzMjfHQjd5M6WZ8hAeVqA3TKwTA=
-github.com/gethinode/mod-utils/v6 v6.5.1 h1:HhCN8Bc0cWxIY0ukjKP9O3jDbKg9F/YaTPO6vqjjk+I=
-github.com/gethinode/mod-utils/v6 v6.5.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
+github.com/gethinode/mod-utils/v6 v6.6.0 h1:b+xpvPUqDKcQr1LUU4YKqtr7zIpzZ7zxCrlpLtlyr5Y=
+github.com/gethinode/mod-utils/v6 v6.6.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 h1:QDKcU3q39lFGzdVwM6kgCGnW3ibbMfYIi0Rwl62iJpo=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0/go.mod h1:5GdMfPAXzbA2gXBqTjC6l27kioSYzHlqDMh0+wyx7sU=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=

--- a/layouts/_partials/assets/adapters/hugo.html
+++ b/layouts/_partials/assets/adapters/hugo.html
@@ -41,9 +41,22 @@
 {{ $height := or $args.imageHeight $args.height -}}
 {{ $width := or $args.imageWidth $args.width -}}
 
+{{/* Resolve the intrinsic page; fall back to the global page for one release */}}
+{{- $page := $args.page -}}
+{{- if not $page -}}
+    {{- $noop := partial "utilities/LogWarn.html" (dict
+        "partial" "assets/adapters/hugo.html"
+        "warnid"  "warn-missing-page-argument"
+        "msg"     "Missing argument 'page', falling back to the global page context"
+        "details" (slice "Pass the rendering page explicitly; this fallback will be removed in a future release")
+        "file"    page.File
+    ) -}}
+    {{- $page = page -}}
+{{- end -}}
+
 {{/* Initialize image if needed, do not raise additional warnings */}}
 {{ if and (not $img) (ne $args.format "svg") }}
-    {{- $res := partial "utilities/GetImage.html" (dict "url" $url "page" page) -}}
+    {{- $res := partial "utilities/GetImage.html" (dict "url" $url "page" $page) -}}
     {{ if $res }}
         {{ $img = $res.resource }}
         {{/* TODO: $res.mirror  */}}

--- a/layouts/_partials/assets/card-group.html
+++ b/layouts/_partials/assets/card-group.html
@@ -74,7 +74,7 @@
     {{- end -}}
     {{- $list = first $paginator.PagerSize (after (mul (sub $paginator.PageNumber 1) $paginator.PagerSize) $list) -}}
 
-    {{- page.Store.Set "paginator" $paginator -}}
+    {{- $args.page.Store.Set "paginator" $paginator -}}
 {{- end -}}
 
 {{/* Initialize list elements */}}
@@ -148,6 +148,7 @@
         {{- if $args.bento }}{{ with $args.valign }} align-items-{{ . }}{{ end }}{{ else }} {{ $colGrid }}{{ end }}">
             {{- range $index, $element := $elements -}}
                 {{- $params := (dict
+                    "page"          $args.page
                     "class"         $class
                     "color"         $args.color
                     "header-style"  (or $args.headerStyle $args.header)

--- a/layouts/_partials/assets/card.html
+++ b/layouts/_partials/assets/card.html
@@ -25,6 +25,7 @@
 
 {{/* Inline partial to render the card's body */}}
 {{- define "_partials/inline/card-body.html" -}}
+    {{- $page := .page -}}
     {{- $title := .title -}}
     {{- $href := .href -}}
     {{- $color := .color -}}
@@ -38,7 +39,7 @@
         <a href="{{ $href }}" class="{{ if $color }}link-bg-{{ $color }}{{ else }}card-body-link{{ end }} stretched-link {{ $class }}">
             {{ if or $title $links }}
                 <p class="card-title {{ $fs }}">
-                    {{- with $title }}{{ . | page.RenderString }}{{ end }}
+                    {{- with $title }}{{ . | $page.RenderString }}{{ end }}
                     {{ with $links }}{{ partial "inline/card-icons.html" (dict "links" .) }}{{ end -}}
                     {{- with $linkIcon -}}<span class="card-link-icon">{{- partial "assets/icon.html" (dict "icon" . "spacing" false) -}}</span>{{- end -}}
                 </p>
@@ -53,7 +54,7 @@
         <div{{ with $class }} class="{{ . }}"{{ end }}>
             {{ if or $title $links }}
                 <p class="card-title {{ $fs }}">
-                    {{- with $title }}{{ . | page.RenderString }}{{ end }}
+                    {{- with $title }}{{ . | $page.RenderString }}{{ end }}
                     {{ with $links }}{{ partial "inline/card-icons.html" (dict "links" .) }}{{ end -}}
                 </p>
             {{ end -}}
@@ -162,6 +163,20 @@
     {{- if not $args.mode }}{{ $mode = (or (and (reflect.IsMap .Params.Thumbnail) .Params.Thumbnail.mode) false) }}{{ end -}}
 {{- end -}}
 
+{{/* Resolve the page used for inline markdown rendering; prefer the card's target page and
+     fall back to the global page for one release */}}
+{{- $renderPage := or $page $args.page -}}
+{{- if not $renderPage -}}
+    {{- $noop := partial "utilities/LogWarn.html" (dict
+        "partial" "assets/card.html"
+        "warnid"  "warn-missing-page-argument"
+        "msg"     "Missing argument 'page', falling back to the global page context"
+        "details" (slice "Pass the rendering page explicitly; this fallback will be removed in a future release")
+        "file"    page.File
+    ) -}}
+    {{- $renderPage = page -}}
+{{- end -}}
+
 {{- $style := $args.iconStyle }}
 {{ if (hasPrefix $args.orientation "horizontal") }}
     {{ if not $args.iconStyle }}{{ $style = "fa-fluid fa-fw" }}{{ end }}
@@ -182,6 +197,7 @@
 {{- $linkIcon := cond (and $linkIconEnabled $href (not $args.button) (not $args.buttonLabel)) $cardLinkIcon "" -}}
 
 {{- $thumbnailArgs := dict
+    "page"     $renderPage
     "src"      $thumbnail
     "portrait" $args.portrait
     "anchor"   $anchor
@@ -246,6 +262,7 @@
                             </div>
                         {{ end }}
                         {{- partial "inline/card-body.html" (dict
+                            "page"        $renderPage
                             "title"       (cond $minimal "" $title)
                             "href"        $href
                             "color"       $args.color
@@ -308,6 +325,7 @@
             {{- if $overlay }}data-bs-theme="dark"{{ end }}>
             {{ if $page }}{{- partial "inline/card-caption.html" (dict "page" $page "keywords" $args.headerStyle "color" $args.color) -}}{{ end }}
             {{- partial "inline/card-body.html" (dict
+                "page"        $renderPage
                 "title"       (cond $minimal "" $title)
                 "href"        $href
                 "color"       $args.color

--- a/layouts/_partials/assets/download.html
+++ b/layouts/_partials/assets/download.html
@@ -19,9 +19,22 @@
     {{ $error = $args.err }}
 {{ end }}
 
+{{/* Resolve the intrinsic page; fall back to the global page for one release */}}
+{{- $page := $args.page -}}
+{{- if not $page -}}
+    {{- $noop := partial "utilities/LogWarn.html" (dict
+        "partial" "assets/download.html"
+        "warnid"  "warn-missing-page-argument"
+        "msg"     "Missing argument 'page', falling back to the global page context"
+        "details" (slice "Pass the rendering page explicitly; this fallback will be removed in a future release")
+        "file"    page.File
+    ) -}}
+    {{- $page = page -}}
+{{- end -}}
+
 {{ $download := "" }}
 {{ if not $error }}
-    {{- $download = partial "utilities/GetTargetPath.html" (dict "path" $args.download "page" page) -}}
+    {{- $download = partial "utilities/GetTargetPath.html" (dict "path" $args.download "page" $page) -}}
     {{- if and $download (not (fileExists (path.Join "static" $download))) -}}
         {{ if page.File }}
             {{- errorf "Cannot find download file for page '%s': %s" page.File.Path $download -}}

--- a/layouts/_partials/assets/featured-illustration.html
+++ b/layouts/_partials/assets/featured-illustration.html
@@ -45,6 +45,7 @@
 {{- else if $image -}}
     {{- if not (hasSuffix $image "svg") }}{{ $class = strings.TrimSpace (printf "%s rounded" (or $class "")) }}{{ end -}}
     {{- partial "assets/live-image.html" (dict
+        "page"     $args.page
         "src"      $image
         "anchor"   $args.anchor
         "ratio"    $args.ratio

--- a/layouts/_partials/assets/helpers/image-dimension.html
+++ b/layouts/_partials/assets/helpers/image-dimension.html
@@ -143,7 +143,8 @@
 {{ if or (hasSuffix $src "svg") $isStatic $args.plain }}
     {{- $targetURL = partial "utilities/GetStaticURL" (dict "url" $staticPath) -}}
 {{ else if (gt (len $dims) 0) }}
-    {{- $targetURL = partial "assets/helpers/image-set.html" (dict 
+    {{- $targetURL = partial "assets/helpers/image-set.html" (dict
+        "page"          $args.page
         "src"           $src
         "img"           (partial "utilities/OmitEmpty.html" $img)
         "dims"          ($dims | last 1)
@@ -154,7 +155,8 @@
         "include-width" false
     )}}
     {{ if $args.imageset }}
-        {{- $set = partial "assets/helpers/image-set.html" (dict 
+        {{- $set = partial "assets/helpers/image-set.html" (dict
+            "page"          $args.page
             "src"           $src
             "img"           (partial "utilities/OmitEmpty.html" $img)
             "dims"          $dims

--- a/layouts/_partials/assets/helpers/image-set.html
+++ b/layouts/_partials/assets/helpers/image-set.html
@@ -38,7 +38,8 @@
         {{ $width := (int (index (split $dim "x") 0)) }}
         {{ $height := (int (index (split $dim "x") 1)) }}
 
-        {{- $element := partial $adapter (dict 
+        {{- $element := partial $adapter (dict
+            "page"         $args.page
             "url-host"     $host
             "url-dir"      $dir
             "url-file"     $file

--- a/layouts/_partials/assets/helpers/navbar-item.html
+++ b/layouts/_partials/assets/helpers/navbar-item.html
@@ -38,7 +38,7 @@
 {{- $tab := site.Params.main.externalLinks.tab -}}
 {{- if (isset $params "tab") }}{{ $tab = $params.tab }}{{ end -}}
 {{- $externalLink := partial "utilities/GetThemeIcon.html" (dict "id" "externalLink" "default" "fas up-right-from-square") -}}
-{{- $baseURL := $page.Scratch.Get "baseURL" | default "/" -}}
+{{- $baseURL := partialCached "utilities/GetBaseURL.html" site | default "/" -}}
 {{- $menuURL := "" -}}
 {{ if or (strings.HasPrefix $entry.PageRef "http") (strings.HasPrefix $entry.URL "http") }}
     {{ $menuURL = or $entry.PageRef $entry.URL }}

--- a/layouts/_partials/assets/image.html
+++ b/layouts/_partials/assets/image.html
@@ -19,13 +19,26 @@
     {{- $error = $args.err -}}
 {{- end -}}
 
+{{/* Resolve the intrinsic page; fall back to the global page for one release */}}
+{{- $page := $args.page -}}
+{{- if not $page -}}
+    {{- $noop := partial "utilities/LogWarn.html" (dict
+        "partial" "assets/image.html"
+        "warnid"  "warn-missing-page-argument"
+        "msg"     "Missing argument 'page', falling back to the global page context"
+        "details" (slice "Pass the rendering page explicitly; this fallback will be removed in a future release")
+        "file"    page.File
+    ) -}}
+    {{- $page = page -}}
+{{- end -}}
+
 {{/* Initialize global arguments */}}
 {{- $absoluteURL := site.Params.main.canonifyAssetsURLs | default false -}}
 {{- $modes := site.Params.main.modes | default (slice "light" "dark") -}}
 
 {{/* Initialize local arguments */}}
 {{- $caption := $args.caption -}}
-{{- if and site.Params.main.titleCase (not page.Params.exact) (eq $caption (plainify $caption)) -}}
+{{- if and site.Params.main.titleCase (not $page.Params.exact) (eq $caption (plainify $caption)) -}}
     {{- $caption = title $caption -}}
 {{- end -}}
 {{- $src := or $args.src $args.url -}}
@@ -33,7 +46,7 @@
 {{/* Main code */}}
 {{- $params := dict -}}
 {{- $params = merge $params (dict
-    "page"         $args.page
+    "page"         $page
     "ratio"        $args.ratio
     "portrait"     $args.portrait
     "image-width"  $args.imageWidth

--- a/layouts/_partials/assets/links.html
+++ b/layouts/_partials/assets/links.html
@@ -19,11 +19,25 @@
     {{ $error = $args.err }}
 {{ end }}
 
+{{/* Resolve the intrinsic page; fall back to the global page for one release */}}
+{{- $page := $args.page -}}
+{{- if not $page -}}
+    {{- $noop := partial "utilities/LogWarn.html" (dict
+        "partial" "assets/links.html"
+        "warnid"  "warn-missing-page-argument"
+        "msg"     "Missing argument 'page', falling back to the global page context"
+        "details" (slice "Pass the rendering page explicitly; this fallback will be removed in a future release")
+        "file"    page.File
+    ) -}}
+    {{- $page = page -}}
+{{- end -}}
+
 {{/* Initialize global arguments */}}
 {{- $breakpoint := page.Scratch.Get "breakpoint" -}}
 {{- $padding := partial "utilities/GetPadding.html" -}}
 
 {{- define "_partials/links-content.html" -}}
+    {{- $page := .page -}}
     {{ $links := .links }}    
     {{ $justify := .justify }}
     {{ $type := .type }}
@@ -40,7 +54,7 @@
 
         {{ $url := "" }}
         {{ with .url }}
-            {{ $link := partial "utilities/GetLink.html" (dict "page" page "href" .) }}
+            {{ $link := partial "utilities/GetLink.html" (dict "page" $page "href" .) }}
             {{ if not $link.error }}
                 {{ $url = $link.href }}
             {{ else }}
@@ -54,7 +68,8 @@
         {{ if (eq $li true) }}<div>{{ end }}
 
         {{ if .download }}
-            {{ partial "assets/download.html" (dict 
+            {{ partial "assets/download.html" (dict
+                "page"        $page
                 "download"    .download
                 "title"       $title
                 "icon"        .icon
@@ -96,9 +111,9 @@
 {{ end }}
 
 <div class="hstack d-none d-{{ $breakpoint.current }}-block {{ if gt (len $args.links) 1 }} gap-5{{ end }} justify-content-{{ $args.align }} pt-{{ $padding.y }}">
-    {{ partial "links-content.html" (dict "links" $args.links "justify" $args.justify "type" $args.linkType "li" false) }}
+    {{ partial "links-content.html" (dict "page" $page "links" $args.links "justify" $args.justify "type" $args.linkType "li" false) }}
 </div>
 
 <div class="d-{{ $breakpoint.current }}-none pt-{{ $padding.y }}">
-    {{ partial "links-content.html" (dict "links" $args.links "justify" $args.justify "type" $args.linkType "li" false) }}
+    {{ partial "links-content.html" (dict "page" $page "links" $args.links "justify" $args.justify "type" $args.linkType "li" false) }}
 </div>

--- a/layouts/_partials/assets/navbar.html
+++ b/layouts/_partials/assets/navbar.html
@@ -50,7 +50,7 @@
 {{- $pretty := site.Params.main.internalLinks.pretty | default false }}
 {{- $id := $args.id | default (printf "navbar-%d" 0) -}}
 {{- $page := $args.page -}}
-{{- $baseURL := $page.Scratch.Get "baseURL" -}}
+{{- $baseURL := partialCached "utilities/GetBaseURL.html" site -}}
 {{- $breakpoint := or $args.breakpoint $args.size }}
 
 {{- $defaultMenu := "main" -}}
@@ -107,6 +107,7 @@
         {{ $height := index site.Params.navigation "logo-height" | default 30 }}
         {{ $class := cond (eq $align "start") "my-auto" "m-auto" }}
         {{ $logo = partial "assets/image.html" (dict
+            "page"         $page
             "src"          .
             "loading"      "eager"
             "title"        $title
@@ -147,7 +148,9 @@
                      In shell mode, the L1 sidebar lives outside the navbar at
                      ≥breakpoint and the offcanvas toggler is emitted at the
                      trailing edge below instead. */}}
-                {{ $sidebar := $page.Scratch.Get "sidebar" }}
+                {{ $version := partial "utilities/GetVersion.html" (dict "page" $page "base" true) }}
+                {{ $disable := eq (index $page.Params "sidebar-menu") false }}
+                {{ $sidebar := (partialCached "utilities/GetVersionedMenu.html" (dict "page" $page "version" $version) $page.Section $version $page.Kind $disable).menu }}
                 {{- if and (not $shell) (or $sidebar (eq $align "center")) -}}
                     <div class="d-flex align-items-center">
                         {{- if $sidebar -}}

--- a/layouts/_partials/assets/page-alert.html
+++ b/layouts/_partials/assets/page-alert.html
@@ -17,9 +17,17 @@
 {{ end }}
 
 {{/* Initialize local arguments */}}
-{{- $pageAlertMsg := $args.page.Scratch.Get "pageAlertMsg" -}}
-{{- $pageAlertURL := $args.page.Scratch.Get "pageAlertURL" -}}
-{{- $version := $args.page.Scratch.Get "version" -}}
+{{- $page := $args.page -}}
+{{- $version := partial "utilities/GetVersion.html" (dict "page" $page "base" true) -}}
+{{- $disable := eq (index $page.Params "sidebar-menu") false -}}
+{{- $vstate := partialCached "utilities/GetVersionedMenu.html" (dict "page" $page "version" $version) $page.Section $version $page.Kind $disable -}}
+
+{{- $pageAlertMsg := "" -}}
+{{- $pageAlertURL := "" -}}
+{{- if $vstate.isOlder -}}
+    {{- $pageAlertMsg = T "newerVersionAlert" site.Title -}}
+    {{- $pageAlertURL = or site.Params.docs.latestURL site.baseURL -}}
+{{- end -}}
 
 {{/* Main code */}}
 {{- if and (not $args.err) $pageAlertMsg -}}

--- a/layouts/_partials/assets/persona.html
+++ b/layouts/_partials/assets/persona.html
@@ -72,6 +72,7 @@
     {{ $illustration := "" }}
     {{- if $thumbnail -}}
         {{- $illustration = partial "assets/image.html" (dict
+            "page"    (partial "utilities/OmitEmpty.html" $page)
             "src"     $thumbnail
             "title"   $title
             "ratio"   "1x1"

--- a/layouts/_partials/assets/section-title.html
+++ b/layouts/_partials/assets/section-title.html
@@ -14,6 +14,19 @@
     )}}
 {{ end }}
 
+{{/* Resolve the intrinsic page; fall back to the global page for one release */}}
+{{- $page := $args.page -}}
+{{- if not $page -}}
+    {{- $noop := partial "utilities/LogWarn.html" (dict
+        "partial" "assets/section-title.html"
+        "warnid"  "warn-missing-page-argument"
+        "msg"     "Missing argument 'page', falling back to the global page context"
+        "details" (slice "Pass the rendering page explicitly; this fallback will be removed in a future release")
+        "file"    page.File
+    ) -}}
+    {{- $page = page -}}
+{{- end -}}
+
 {{/* Initialize global arguments */}}
 {{- $breakpoint := partial "utilities/GetBreakpoint.html" -}}
 {{- $padding := partial "utilities/GetPadding.html" -}}
@@ -27,27 +40,28 @@
 {{- $title := $args.heading.title }}
 {{- $width := $args.heading.width | default 12 -}}
 {{- $width = cond (lt $width 12) (printf "col-12 col-%s-%d" $breakpoint.current $width) "" }}
-{{- if and (not $preheading) $args.useSection }}{{ $preheading = page.CurrentSection.Name }}{{ end -}}
+{{- if and (not $preheading) $args.useSection }}{{ $preheading = $page.CurrentSection.Name }}{{ end -}}
 {{- $justify := cond (eq $args.justify "start") "" (cond (eq $args.justify "end") "me-0" "mx-auto") -}}
 
-{{ if and site.Params.main.titleCase (not $args.page.Params.exact) }}
+{{ if and site.Params.main.titleCase (not $page.Params.exact) }}
     {{ $preheading = title $preheading }}
     {{ $title = title $title }}
 {{ end }}
 
 {{ define "_partials/assets/section-title-header.html" }}
+    {{- $page := .page }}
     {{ $headingStyle := .headingStyle }}
 
     {{ if (index . "use-title") }}
-        {{ $title := .title | page.RenderString }}
+        {{ $title := .title | $page.RenderString }}
         {{ $label := trim (replaceRE "\r\n?|\n" " " ($title | plainify)) " " }}
-        <h1 id="{{ anchorize .title }}" {{ if ne $title $label }}aria-label="{{ $label }}"{{ end -}}        
+        <h1 id="{{ anchorize .title }}" {{ if ne $title $label }}aria-label="{{ $label }}"{{ end -}}
             class="{{ $headingStyle }}-{{ .size }}{{ with .color }} text-{{ . }}{{ end }} pt-1">
-                {{ .title | page.RenderString | safeHTML }}
+                {{ .title | $page.RenderString | safeHTML }}
         </h1>
     {{ else }}
         <div id="{{ anchorize .title }}" class="{{ $headingStyle }}-{{ .size }}{{ with .color }} text-{{ . }}{{ end }} pt-1">
-            {{ .title | page.RenderString | safeHTML }}
+            {{ .title | $page.RenderString | safeHTML }}
         </div>
     {{ end }}
 {{ end }}
@@ -55,6 +69,7 @@
 {{ $header := "" }}
 {{ if $title }}
     {{ $header = partial "assets/section-title-header.html" (dict
+        "page"         $page
         "use-title"    $args.useTitle
         "title"        $title
         "headingStyle" $headingStyle
@@ -66,7 +81,7 @@
 {{ $links := "" }}
 {{ if $args.links }}
     {{ $links = partial "assets/links.html" (dict
-        "page"      $args.page
+        "page"      $page
         "links"     $args.links
         "align"     $args.heading.align
         "justify"   $args.justify
@@ -83,14 +98,14 @@
                     <div class="col-12 col-{{ $breakpoint.current }}-2 p-0">
                         {{ with $preheading }}
                             <p class="preheading {{ if ne $args.color "body" }}text-{{ $args.color }}{{ else }}text-primary{{ end }}">
-                                {{ . | page.RenderString | safeHTML }}
+                                {{ . | $page.RenderString | safeHTML }}
                             </p>
                         {{ end }}
                     </div>
                     <div class="col-12 col-{{ $breakpoint.current }}-8 p-0">
                         {{ $header }}
                         {{ with $args.heading.content }}
-                            <div class="{{ $contentStyle }} pt-{{ $padding.y }}">{{ . | page.RenderString | safeHTML }}</div>
+                            <div class="{{ $contentStyle }} pt-{{ $padding.y }}">{{ . | $page.RenderString | safeHTML }}</div>
                         {{ end }}
                         {{ $links }}
                     </div>
@@ -101,11 +116,11 @@
         {{ else }}
             {{ with $preheading }}
                 <p class="preheading {{ if ne $args.color "body" }}text-{{ $args.color }}{{ else }}text-primary{{ end }}">
-                    {{ . | page.RenderString | safeHTML }}
+                    {{ . | $page.RenderString | safeHTML }}
                 </p>
             {{ end }}
             {{ $header }}
-            {{ with $args.heading.content }}<div class="{{ $contentStyle }} pt-{{ $padding.y }}">{{ . | page.RenderString | safeHTML }}</div>{{ end }}
+            {{ with $args.heading.content }}<div class="{{ $contentStyle }} pt-{{ $padding.y }}">{{ . | $page.RenderString | safeHTML }}</div>{{ end }}
             {{ $links }}
         {{ end }}
     </div>

--- a/layouts/_partials/assets/sidebar.html
+++ b/layouts/_partials/assets/sidebar.html
@@ -270,6 +270,7 @@
             <a class="sidebar-brand text-decoration-none" href="{{ $logoHome }}" aria-label="{{ T "home" }}">
                 {{- with $logo -}}
                     {{ partial "assets/image.html" (dict
+                        "page"         $args.page
                         "src"          .
                         "loading"      "eager"
                         "title"        site.Title
@@ -280,6 +281,7 @@
                 {{- end -}}
                 {{- with $logoCollapsed -}}
                     {{ partial "assets/image.html" (dict
+                        "page"         $args.page
                         "src"          .
                         "loading"      "eager"
                         "title"        site.Title

--- a/layouts/_partials/assets/timeline.html
+++ b/layouts/_partials/assets/timeline.html
@@ -139,6 +139,7 @@
     {{ $title := "" }}
     {{ if $args.heading }}
         {{ $title = partial "assets/section-title.html" (dict
+            "page"        $page
             "heading"     $args.heading
             "use-title"   $args.useTitle
             "size"        $args.size

--- a/layouts/_partials/assets/toc-parse-content.html
+++ b/layouts/_partials/assets/toc-parse-content.html
@@ -52,13 +52,9 @@
 
 {{- /* Render */}}
 {{- if .Site.Params.navigation.toc }}
-    {{- /* Check for custom headings in Page.Store or Page.Params, otherwise use Page.Fragments */}}
-    {{- $customHeadings := .Page.Store.Get "Headings" }}
-    {{- $customHeadingsMap := .Page.Store.Get "HeadingsMap" }}
-    {{- if not $customHeadings }}
-        {{- $customHeadings = .Page.Params.Headings }}
-        {{- $customHeadingsMap = .Page.Params.HeadingsMap }}
-    {{- end }}
+    {{- /* Check for custom headings in Page.Params, otherwise use Page.Fragments */}}
+    {{- $customHeadings := .Page.Params.Headings }}
+    {{- $customHeadingsMap := .Page.Params.HeadingsMap }}
 
     {{- $fragments := cond $customHeadings (dict "Headings" $customHeadings "HeadingsMap" $customHeadingsMap) .Page.Fragments }}
 

--- a/layouts/_partials/page/articles.html
+++ b/layouts/_partials/page/articles.html
@@ -6,6 +6,7 @@
     {{ partial "assets/breadcrumb.html" (dict "page" .) }}
 {{ end }}
 {{ partial "assets/section-title.html" (dict
+    "page"    .
     "heading" (dict
         "title"   .Title
         "content" .Description
@@ -45,6 +46,7 @@
                 {{ range $pages }}
                     <div class="col">
                         {{ partial "assets/card.html" (dict
+                            "page"         $
                             "title"        .Title
                             "thumbnail"    .Thumbnail
                             "description"  .Description
@@ -61,6 +63,7 @@
                 {{ range (.Paginate $pages).Pages }}
                     <div class="col">
                         {{ partial "assets/card.html" (dict
+                            "page"         $
                             "path"         .RelPermalink
                             "class"        $class
                             "padding"      $cardPadding

--- a/layouts/_partials/page/thumbnail.html
+++ b/layouts/_partials/page/thumbnail.html
@@ -37,6 +37,7 @@
 
 {{ if $thumbnail -}}
     {{- partial "assets/image.html" (dict
+        "page"     $page
         "src"      $thumbnail
         "anchor"   (partial "utilities/OmitEmpty.html" $anchor)
         "ratio"    $ratio

--- a/layouts/_partials/utilities/GetIllustration.html
+++ b/layouts/_partials/utilities/GetIllustration.html
@@ -16,6 +16,7 @@
     {{ if reflect.IsMap $item.Params.Thumbnail }}{{ $thumbnail = $item.Params.Thumbnail.url }}{{ else }}{{ $thumbnail = $item.Params.Thumbnail }}{{ end }}
     {{- if $thumbnail }}
         {{ $illustration = partial "assets/image.html" (dict
+            "page"    $item
             "src"     $thumbnail
             "ratio"   "16x9"
             "wrapper" $style

--- a/layouts/_partials/utilities/GetVersionedMenu.html
+++ b/layouts/_partials/utilities/GetVersionedMenu.html
@@ -1,0 +1,42 @@
+{{/*
+    Copyright © 2026 The Hinode Team / Mark Dumay. All rights reserved.
+    Use of this source code is governed by The MIT License (MIT) that can be found in the LICENSE file.
+    Visit gethinode.com/license for more details.
+
+    Computes the version-aware sidebar state of a page: the docs version (base label), the
+    matching sidebar menu, and whether that version is older than the site's latest release.
+    This is the same logic baseof.html uses to seed the "version", "sidebar", "pageAlertMsg",
+    and "pageAlertURL" scratch values, extracted so layout and shortcode paths can share it
+    without reading the page's scratch (which is unreliable outside the page's own render).
+
+    The result is a pure function of the page's section, docs version, kind, and "sidebar-menu"
+    page parameter. Callers on a hot path should invoke it as:
+
+        partialCached "utilities/GetVersionedMenu.html" (dict "page" $page "version" $version)
+            $page.Section $version $page.Kind $disable
+
+    with $version obtained from "utilities/GetVersion.html" (cheap) and $disable reflecting the
+    page's "sidebar-menu" parameter. baseof.html deliberately calls it uncached so the
+    "sidebarFilename" diagnostic that GetMenu records on the page's scratch keeps landing on
+    every page.
+
+    Arguments:
+    - page:    context of the intrinsic page (required)
+    - version: precomputed base version of the page (optional)
+
+    Returns a dict with the keys "version" (string), "menu" (menu data or ""), and "isOlder"
+    (bool).
+*/}}
+
+{{- $page := .page -}}
+{{- $version := or .version (partial "utilities/GetVersion.html" (dict "page" $page "base" true)) -}}
+{{- $menu := partial "utilities/GetMenu" (dict "page" $page "version" $version) -}}
+
+{{- $isOlder := false -}}
+{{- if and site.Params.docs.checkVersion $version -}}
+    {{- if ne $version "latest" -}}
+        {{- $isOlder = partial "utilities/IsOlder" (dict "current" $version) -}}
+    {{- end -}}
+{{- end -}}
+
+{{- return (dict "version" $version "menu" $menu "isOlder" $isOlder) -}}

--- a/layouts/_shortcodes/card.html
+++ b/layouts/_shortcodes/card.html
@@ -73,6 +73,7 @@
 {{ if not $error -}}
     {{/* Render card */}}
     {{- $output := partial "assets/card.html" (dict
+        "page"         $page
         "path"         $path
         "href"         $args.href
         "title"        $title

--- a/layouts/_shortcodes/table.html
+++ b/layouts/_shortcodes/table.html
@@ -41,7 +41,10 @@
 {{ $page := .Page }}
 {{ $filtered := gt (len (findRE `[^,\s]` (printf "%v" (or $args.filter "")) 1)) 0 }}
 {{ if or $args.sortable $args.paginate $args.searchable $filtered }}
-    {{ with $page.Scratch.Get "modules" }}
+    {{- /* Mirror the cache shape of baseof.html: page context, no variant key, so both share a
+         single cached entry per language. InitModules needs a page context (it calls .IsPage
+         and .Site), which rules out `site` here. */}}
+    {{ with partialCached "utilities/InitModules.html" $page }}
         {{ if in (.optional | default slice) "simple-datatables" }}
             {{ $pageModules := slice | append $page.Params.modules }}
             {{ if not (in $pageModules "simple-datatables") }}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,16 +1,15 @@
-{{- /* Set version-aware sidebar menu */ -}}
-{{- $version := partial "utilities/GetVersion.html" (dict "page" . "base" true) -}}
+{{- /* Set version-aware sidebar menu. The helper is called uncached on purpose: GetMenu
+       records the "sidebarFilename" diagnostic on the page's scratch, which should land on
+       every page. The scratch seeds below remain for downstream readers. */ -}}
+{{- $vstate := partial "utilities/GetVersionedMenu.html" (dict "page" .) -}}
+{{- $version := $vstate.version -}}
 {{- $.Scratch.Set "version" $version -}}
-{{ with partial "utilities/GetMenu" (dict "page" . "version" $version) }}{{ $.Scratch.Set "sidebar" . }}{{ end }}
+{{ with $vstate.menu }}{{ $.Scratch.Set "sidebar" . }}{{ end }}
 
 {{- /* Validate if current version is latest */ -}}
-{{- if and site.Params.docs.checkVersion $version -}}
-    {{- if ne $version "latest" -}}
-        {{- if partial "utilities/IsOlder" (dict "current" $version) -}}
-            {{- $.Scratch.Set "pageAlertMsg" (T "newerVersionAlert" site.Title) -}}
-            {{- $.Scratch.Set "pageAlertURL" (or site.Params.docs.latestURL site.baseURL) -}}
-        {{- end -}}
-    {{- end -}}
+{{- if $vstate.isOlder -}}
+    {{- $.Scratch.Set "pageAlertMsg" (T "newerVersionAlert" site.Title) -}}
+    {{- $.Scratch.Set "pageAlertURL" (or site.Params.docs.latestURL site.baseURL) -}}
 {{- end -}}
 
 {{- /* Initialize module configuration */ -}}

--- a/layouts/toc.html
+++ b/layouts/toc.html
@@ -5,7 +5,8 @@
     <div class="toc toc-sidebar mb-5 my-md-0 mb-lg-5 pb-3 text-body-secondary sticky-top">
         {{ if $download }}
             <div class="mb-5 p-0">
-                {{ partial "assets/download.html" (dict 
+                {{ partial "assets/download.html" (dict
+                    "page"        .
                     "download"    $download
                     "outline"     true
                     "button-size" "sm"


### PR DESCRIPTION
## Render-once program — slice D5 (HELD for maintainer review)

Part of the Hinode render-once implementation program (design:
gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md` §4.5/§6-D5,
decisions §8-Q2/Q6).

### Changes
- **section-title / card / image** — accept and use the intrinsic page (schemas gain optional
  `page`); all in-tree callers thread it (incl. image callers: persona, sidebar logos, timeline,
  thumbnail, featured-illustration, articles). Omitted `page` → LogWarn (`warnidf`) + global
  fallback for one release (§8-Q6).
- **links / download / adapters-hugo** — bare `"page" page` fills → `$args.page`.
- **navbar / navbar-item** — baseURL Scratch reads → `partialCached utilities/GetBaseURL.html
  site` (mod-utils v6.6.0); baseof seed stays until D9.
- **New `utilities/GetVersionedMenu.html`** — extracts baseof's version/menu/isOlder logic;
  navbar:150 + page-alert consume it with the intrinsic page (`partialCached` keyed
  Section+version+Kind+sidebar-menu-disable); baseof calls it uncached so GetMenu's
  `sidebarFilename` diagnostic still lands per page.
- **table shortcode** — `modules` Scratch read → `partialCached utilities/InitModules.html`
  (page-context shape mirrors baseof's cache; `site` context errors on `.IsPage`).
- **card-group** — `paginator` Store write → `$args.page.Store.Set` (consumer defer-ized in D6).
- **toc-parse-content** — dead `Headings`/`HeadingsMap` Store reads retired (§8-Q2; grep-verified
  no setter).
- **go.mod** — mod-utils v6.5.1 → v6.6.0 only (MVS drag of mod-fontawesome/FA pinned back;
  attribution table in the program register evidence).
- **exampleSite** — transitional `warn-missing-page-argument` in `ignoreErrors`: the pinned
  mod-blocks v2.1.4 omits `page` in section-title/image calls until #2038's v2.2.0 bump lands.
  **Remove when the exampleSite resolves mod-blocks ≥2.2.0** (tracked in the program register).

### Gate evidence (byte-diff, exampleSite, hugo v0.164.0)
- Stock ×2 + candidate ×2: 0 ERROR, 98/26/24 pages, WARN set byte-identical.
- Candidate-vs-stock: only the 3 allowlisted RSS files (verified px-0/px-4 `blocks_embed` race).
- Run-vs-run: clean. Independently re-verified by the program driver (zero non-allowlisted).
- `pnpm test` green.
- Note: LogWarn fallback output is captured (`$noop`) — the partial's rendered text otherwise
  leaks into RSS-embedded `.Content` (found by the gate, one fix round).

### Sequencing
Recommended merge order: #2037 (D3) → #2038 (D4) → this → D6. Touches `assets/sidebar.html`
(2 lines, image page-threading) which #2039 (E) rewrites — rebase #2039 after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)