### PR TITLE
fix: make the footer script dependency read contract-based (render-once D6)

### DIFF
--- a/layouts/_partials/footer/scripts.html
+++ b/layouts/_partials/footer/scripts.html
@@ -123,7 +123,16 @@
 {{- else -}}
     {{- $page_modules = $page_modules | append $args.page.Params.modules -}}
 {{- end -}}
+{{/* Module dependencies are registered in the page's Scratch and Store as a side effect of
+    content rendering (utilities/AddModule.html). Only the "optional" bundle consumes them,
+    and it renders after the body — but materialize the content explicitly so the read is
+    contract-based rather than an ordering accident. .Content is cached, so this is cheap.
+    The critical/functional calls render in the head and must not touch .Content. */}}
+{{- if eq $args.type "optional" -}}
+    {{- $_ := $args.page.Content -}}
+{{- end -}}
 {{- with $args.page.Scratch.Get "dependencies" -}}{{- $page_modules = append $page_modules . | uniq -}}{{- end -}}
+{{- with $args.page.Store.Get "dependencies" -}}{{- $page_modules = append $page_modules . | uniq -}}{{- end -}}
 
 {{- $categories := dict "other" slice -}}
 


### PR DESCRIPTION
## Render-once program — slice D6, shipped subset (HELD for maintainer review)

Part of the Hinode render-once implementation program (design:
gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md` §4.4/§6-D6).

### Changes
- **footer/scripts.html** — the `optional` bundle's module-dependency read now (a) materializes
  `.Content` first (`{{ $_ := .Content }}`, cached — contract instead of ordering accident) and
  (b) reads the Scratch ∪ Store union (mod-utils ≥6.6.0 dual-writes). The critical/functional
  head-side calls deliberately do NOT touch `.Content` (pre-flip that would shift UID numbering
  build-wide).
- **go.mod** — mod-utils v6.5.1 → v6.6.0 only (MVS drag of mod-fontawesome/FA/hinode-graph
  pinned back; attribution in the program register evidence).

### Design outcomes recorded (maintainer decisions 2026-07-16)
- The designed `templates.Defer` head-CSS block is **structurally impossible**: deferred output
  splices unminified into minified pages, and `resources.PostProcess` (stylesheet.html, every
  production build) is forbidden inside deferred templates. The head consumer fix moves to D8 as
  a `.Content` guard + union read (byte-neutral post-flip).
- **D6b / §8-Q1 disproven**: pager pages share the page's `RelPermalink`+`Store`, so a deferred
  OpenGraph block would stamp the last pager's URL on all pager pages. The paginator Store
  plumbing is retired in D9.

### Gate evidence
Stock ×2 + candidate ×2: 0 ERROR, 98/26/24, WARN set identical; run-vs-run and
candidate-vs-stock ⊆ the 3-file RSS allowlist; no-description pages byte-identical.
Independently re-verified by the program driver. `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)