### PR TITLE
feat: accept an owning page argument in the form hook structure (render-once follow-up)

### DIFF
--- a/data/structures/form-hook.yml
+++ b/data/structures/form-hook.yml
@@ -2,6 +2,13 @@ comment: >-
   Renders a form with callback action. Assign a form-id when the form provider
   requires a specific form definition.
 arguments:
+  page:
+    optional: true
+    comment: >-
+      Page that owns the form. Hook implementations should pass it to nested
+      partials with render-context side effects (such as icon sprite
+      registration), so those land on the owning page instead of the page
+      that triggered the current rendering context.
   action:
     optional: false
   form-id:


### PR DESCRIPTION
## Render-once follow-up — clears the last dangling sprite ref

The final sprite-audit residual from hinode#2042's runbook: the contact-form demo's
`fa-paper-plane` renders as a dangling `<use>` ref because mod-docs'
`netlify-contact-form-hook.html` calls `assets/icon.html` without a page — and the
`form-hook` structure rejects one (only `action`/`form-id`).

This PR adds an optional `page` argument to `data/structures/form-hook.yml` (schema-only;
non-breaking — hook implementations that ignore it keep working). Follow-ups once released:
mod-docs threads `page` into its submit-button icon call, and mod-blocks forwards `$page`
in `contact-form.hugo.html`'s hook dispatch — after which the exampleSite sprite audit reads
**0 dangling refs**.

Gate: schema-data-only change; exampleSite build 0 ERROR, 98/26/24, WARN parity vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)