### PR TITLE
fix: render-once cleanup — retire transition seeds, dead plumbing, and diagnostics globals

### DIFF
--- a/data/structures/persona.yml
+++ b/data/structures/persona.yml
@@ -2,6 +2,8 @@ comment: >-
   Displays a custom persona card with thumbnail, title, and optional link.
 icon: account_circle
 arguments:
+  page:
+    optional: true
   path:
     type: path
     optional: true

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -12,10 +12,7 @@ enableInlineShortcodes = true
 
 # prevent build failures when using Hugo's Instagram shortcode due to deprecated Instagram API.
 # See https://github.com/gohugoio/hugo/issues/7228#issuecomment-714490456
-# the 'warn-missing-page-argument' entry suppresses the fallback warning from the args-engine
-# example previews (e.g. the persona structure example), which render partials without a page
-# context; remove it once example previews thread a page.
-ignoreErrors = ["error-remote-getjson", "warn-preview-restricted", "warn-missing-page-argument"]
+ignoreErrors = ["error-remote-getjson", "warn-preview-restricted"]
 # the site's content uses HTML comments (markdownlint directives); with Goldmark's unsafe
 # rendering disabled these trigger 'warning-goldmark-raw-html' and render as harmless
 # '<!-- raw HTML omitted -->' placeholders, which the minifier strips from production output.

--- a/layouts/_partials/assets/adapters/cloudinary.html
+++ b/layouts/_partials/assets/adapters/cloudinary.html
@@ -27,7 +27,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}
@@ -39,7 +39,7 @@
         "partial" "assets/adapter/cloudinary.html" 
         "msg"     "Invalid arguments"
         "details" slice "argument 'url-file': expected value"
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = true }}
 {{ end }}

--- a/layouts/_partials/assets/adapters/hugo.html
+++ b/layouts/_partials/assets/adapters/hugo.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}
@@ -28,7 +28,7 @@
         "partial" "assets/adapter/hugo.html" 
         "msg"     "Invalid arguments"
         "details" slice "argument 'url-file': expected value"
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = true }}
 {{ end }}

--- a/layouts/_partials/assets/adapters/imagekit.html
+++ b/layouts/_partials/assets/adapters/imagekit.html
@@ -27,7 +27,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"    "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}
@@ -39,7 +39,7 @@
         "partial" "assets/adapter/imagekit.html" 
         "msg"     "Invalid arguments"
         "details" slice "argument 'url-file': expected value"
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = true }}
 {{ end }}

--- a/layouts/_partials/assets/adapters/imgix.html
+++ b/layouts/_partials/assets/adapters/imgix.html
@@ -25,7 +25,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 
@@ -36,7 +36,7 @@
         "partial" "assets/adapter/imgix.html" 
         "msg"     "Invalid arguments"
         "details" slice "argument 'url-file': expected value"
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = true }}
 {{ end }}

--- a/layouts/_partials/assets/args.html
+++ b/layouts/_partials/assets/args.html
@@ -91,7 +91,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
     {{- $error = $args.err -}}
 {{- end -}}
@@ -109,7 +109,7 @@
             "warnid"  "warn-invalid-arguments"
             "msg"     "Invalid arguments"
             "details" ($types.errmsg | append $types.warnmsg)
-            "file"    page.File
+            "file"    (or $args.page page).File
         )}}
         {{ $error = $args.err }}
     {{ end }}

--- a/layouts/_partials/assets/breadcrumb.html
+++ b/layouts/_partials/assets/breadcrumb.html
@@ -24,7 +24,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}

--- a/layouts/_partials/assets/button.html
+++ b/layouts/_partials/assets/button.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}

--- a/layouts/_partials/assets/card-group.html
+++ b/layouts/_partials/assets/card-group.html
@@ -24,7 +24,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{- $error = $args.err -}}
 {{- end -}}

--- a/layouts/_partials/assets/card-group.html
+++ b/layouts/_partials/assets/card-group.html
@@ -73,8 +73,6 @@
         {{- $paginator = $args.page.Paginate $list -}}
     {{- end -}}
     {{- $list = first $paginator.PagerSize (after (mul (sub $paginator.PageNumber 1) $paginator.PagerSize) $list) -}}
-
-    {{- $args.page.Store.Set "paginator" $paginator -}}
 {{- end -}}
 
 {{/* Initialize list elements */}}

--- a/layouts/_partials/assets/card-icon.html
+++ b/layouts/_partials/assets/card-icon.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}

--- a/layouts/_partials/assets/card.html
+++ b/layouts/_partials/assets/card.html
@@ -112,7 +112,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}
@@ -133,8 +133,8 @@
     {{ $page = partial "utilities/GetPage.html" (dict "url" $args.path "page" (or $args.page page)) }}
     {{ $validate := site.Params.main.internalLinks.validate | default true }}
     {{- if and $validate (not $page) }}
-        {{ if page.File }}
-            {{- warnf "partial [assets/card.html] - Cannot find target page '%s', see '%s'" $args.path page.File.Path -}}
+        {{ if (or $args.page page).File }}
+            {{- warnf "partial [assets/card.html] - Cannot find target page '%s', see '%s'" $args.path (or $args.page page).File.Path -}}
         {{ else }}
             {{- warnf "partial [assets/card.html] - Cannot find target page '%s'" $args.path -}}
         {{ end }}

--- a/layouts/_partials/assets/carousel-item.html
+++ b/layouts/_partials/assets/carousel-item.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/download.html
+++ b/layouts/_partials/assets/download.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}
@@ -36,8 +36,8 @@
 {{ if not $error }}
     {{- $download = partial "utilities/GetTargetPath.html" (dict "path" $args.download "page" $page) -}}
     {{- if and $download (not (fileExists (path.Join "static" $download))) -}}
-        {{ if page.File }}
-            {{- errorf "Cannot find download file for page '%s': %s" page.File.Path $download -}}
+        {{ if $page.File }}
+            {{- errorf "Cannot find download file for page '%s': %s" $page.File.Path $download -}}
         {{ else }}
             {{- errorf "Cannot find download file: %s" $download -}}
         {{ end }}

--- a/layouts/_partials/assets/featured-illustration.html
+++ b/layouts/_partials/assets/featured-illustration.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
     {{- $error = $args.err -}}
 {{- end -}}

--- a/layouts/_partials/assets/helpers/image-definition.html
+++ b/layouts/_partials/assets/helpers/image-definition.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{- $error = $args.err -}}
 {{- end -}}

--- a/layouts/_partials/assets/helpers/image-dimension.html
+++ b/layouts/_partials/assets/helpers/image-dimension.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}

--- a/layouts/_partials/assets/helpers/image-set.html
+++ b/layouts/_partials/assets/helpers/image-set.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/helpers/navbar-item.html
+++ b/layouts/_partials/assets/helpers/navbar-item.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = true }}
 {{ end }}
@@ -28,7 +28,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" (slice "missing argument `menu-entry`")
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = true }}
 {{ end }}

--- a/layouts/_partials/assets/hero-image.html
+++ b/layouts/_partials/assets/hero-image.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/image.html
+++ b/layouts/_partials/assets/image.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
     {{- $error = $args.err -}}
 {{- end -}}

--- a/layouts/_partials/assets/link.html
+++ b/layouts/_partials/assets/link.html
@@ -15,7 +15,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
     {{- $error = $args.err -}}
 {{- end -}}

--- a/layouts/_partials/assets/links.html
+++ b/layouts/_partials/assets/links.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}
@@ -58,7 +58,7 @@
             {{ if not $link.error }}
                 {{ $url = $link.href }}
             {{ else }}
-                {{ with page.File }}
+                {{ with $page.File }}
                     {{ warnf "Error processing link on page '%s': %s" (path.Join "/content" .Path) $link.msg }}
                 {{ else }}
                     {{ warnf "Error processing link: %s" $link.msg }}

--- a/layouts/_partials/assets/live-image.html
+++ b/layouts/_partials/assets/live-image.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
 {{- end -}}
 

--- a/layouts/_partials/assets/live-pages.html
+++ b/layouts/_partials/assets/live-pages.html
@@ -10,7 +10,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/menu-item.html
+++ b/layouts/_partials/assets/menu-item.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
     {{- $error = $args.err -}}
 {{- end -}}

--- a/layouts/_partials/assets/nav-item.html
+++ b/layouts/_partials/assets/nav-item.html
@@ -13,7 +13,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
 {{- end -}}
 

--- a/layouts/_partials/assets/nav.html
+++ b/layouts/_partials/assets/nav.html
@@ -37,7 +37,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
     {{- $error = $args.err -}}
 {{- end -}}

--- a/layouts/_partials/assets/navbar.html
+++ b/layouts/_partials/assets/navbar.html
@@ -22,7 +22,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/page-alert.html
+++ b/layouts/_partials/assets/page-alert.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/pagination.html
+++ b/layouts/_partials/assets/pagination.html
@@ -177,7 +177,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/persona.html
+++ b/layouts/_partials/assets/persona.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 
@@ -72,7 +72,7 @@
     {{ $illustration := "" }}
     {{- if $thumbnail -}}
         {{- $illustration = partial "assets/image.html" (dict
-            "page"    (partial "utilities/OmitEmpty.html" $page)
+            "page"    (or $page $args.page)
             "src"     $thumbnail
             "title"   $title
             "ratio"   "1x1"

--- a/layouts/_partials/assets/section-title.html
+++ b/layouts/_partials/assets/section-title.html
@@ -10,7 +10,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/sidebar.html
+++ b/layouts/_partials/assets/sidebar.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/stack.html
+++ b/layouts/_partials/assets/stack.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/table.html
+++ b/layouts/_partials/assets/table.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/testimonial.html
+++ b/layouts/_partials/assets/testimonial.html
@@ -148,7 +148,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/assets/timeline.html
+++ b/layouts/_partials/assets/timeline.html
@@ -15,7 +15,7 @@
         "partial" "assets/timeline.html" 
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}
@@ -33,7 +33,7 @@
         "partial" "assets/timeline.html"
         "msg"     "Invalid arguments"
         "details" (slice (printf "Invalid timeline data '%s'" $args.data))
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = true }}
 {{- end -}}
@@ -60,7 +60,7 @@
             "warnid"  "warn-invalid-section"
             "msg"     "Invalid section"
             "details" (slice (printf "Section '%s' not found" $args.section))
-            "file"    page.File
+            "file"    (or $args.page page).File
         ) -}}
     {{- end -}}
 {{- end -}}

--- a/layouts/_partials/assets/toc-dropdown.html
+++ b/layouts/_partials/assets/toc-dropdown.html
@@ -14,7 +14,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}

--- a/layouts/_partials/assets/toc.html
+++ b/layouts/_partials/assets/toc.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}

--- a/layouts/_partials/assets/video.html
+++ b/layouts/_partials/assets/video.html
@@ -27,7 +27,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}

--- a/layouts/_partials/footer/scripts.html
+++ b/layouts/_partials/footer/scripts.html
@@ -98,7 +98,7 @@
         "partial" "footer/scripts.html" 
         "msg"     "Invalid arguments"
         "details" $args.errmsg
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{- $error = true -}}
 {{- end -}}

--- a/layouts/_partials/head/opengraph.html
+++ b/layouts/_partials/head/opengraph.html
@@ -3,12 +3,8 @@
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
 <meta property="og:title" content="{{ $.Scratch.Get "title" }}">
 <meta property="og:description" content="{{ $.Scratch.Get "description" }}">
-{{ $paginator := $.Store.Get "paginator" }}
-{{ if $paginator }}
-    <meta property="og:url" content="{{ $paginator.URL | absURL }}">
-{{ else -}}
-    <meta property="og:url" content="{{ .Permalink }}">
-{{ end -}}
+<meta property="og:url" content="{{ .Permalink }}">
+
 {{ with .Site.Title -}}
     <meta property="og:site_name" content="{{ . }}">
 {{ end -}}

--- a/layouts/_partials/head/stylesheet.html
+++ b/layouts/_partials/head/stylesheet.html
@@ -48,7 +48,7 @@
 {{- $overlayOffset := $navbarOffset -}}
 {{- if site.Params.navigation.overlay }}{{ $overlayOffset = "0rem" }}{{ end }}
 {{- $vars := dict 
-    "base-url"                (page.Scratch.Get "baseURL" | default "/")
+    "base-url"                (partialCached "utilities/GetBaseURL.html" site | default "/")
     "theme-font"              (default "Inter" site.Params.style.themeFont)
     "font-size-base"          (default "1rem" site.Params.style.fontSizeBase)
     "primary"                 (default "#007bff" site.Params.style.primary)

--- a/layouts/_partials/utilities/GetLink.html
+++ b/layouts/_partials/utilities/GetLink.html
@@ -15,7 +15,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $args.err }}
 {{ end }}

--- a/layouts/_shortcodes/abbr.html
+++ b/layouts/_shortcodes/abbr.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/accordion-item.html
+++ b/layouts/_shortcodes/accordion-item.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/accordion.html
+++ b/layouts/_shortcodes/accordion.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}

--- a/layouts/_shortcodes/alert.html
+++ b/layouts/_shortcodes/alert.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/args.html
+++ b/layouts/_shortcodes/args.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     ) -}}
     {{- $error = $args.err -}}

--- a/layouts/_shortcodes/badge.html
+++ b/layouts/_shortcodes/badge.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}

--- a/layouts/_shortcodes/breadcrumb.html
+++ b/layouts/_shortcodes/breadcrumb.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/button-group.html
+++ b/layouts/_shortcodes/button-group.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}

--- a/layouts/_shortcodes/button.html
+++ b/layouts/_shortcodes/button.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/card-group.html
+++ b/layouts/_shortcodes/card-group.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/card.html
+++ b/layouts/_shortcodes/card.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/carousel.html
+++ b/layouts/_shortcodes/carousel.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/collapse.html
+++ b/layouts/_shortcodes/collapse.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err -}}

--- a/layouts/_shortcodes/command.html
+++ b/layouts/_shortcodes/command.html
@@ -18,7 +18,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/docs.html
+++ b/layouts/_shortcodes/docs.html
@@ -23,7 +23,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/docs.md
+++ b/layouts/_shortcodes/docs.md
@@ -8,7 +8,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/example-bookshop.html
+++ b/layouts/_shortcodes/example-bookshop.html
@@ -24,7 +24,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}
@@ -44,7 +44,7 @@
         "resize"      $args.resize
         "showPreview" $showPreview
         "caller"      "shortcodes/example-bookshop.html"
-        "file"        page.File
+        "file"        .Page.File
         "position"    .Position
     ) -}}
 {{- end -}}

--- a/layouts/_shortcodes/example.html
+++ b/layouts/_shortcodes/example.html
@@ -21,7 +21,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}
@@ -40,7 +40,7 @@
         "resize"      $args.resize
         "showPreview" $showPreview
         "caller"      "shortcodes/example.html"
-        "file"        page.File
+        "file"        .Page.File
         "position"    .Position
     ) -}}
     <div class="border {{ if and $showPreview $showMarkup }}rounded mb-3{{ else if $showPreview }}rounded-top border-bottom-0{{ else }}rounded-bottom{{ end }}">

--- a/layouts/_shortcodes/file.html
+++ b/layouts/_shortcodes/file.html
@@ -23,7 +23,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/image.html
+++ b/layouts/_shortcodes/image.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/img.html
+++ b/layouts/_shortcodes/img.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/ins.html
+++ b/layouts/_shortcodes/ins.html
@@ -13,7 +13,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  $args.errmsg
-        "file"     page.File
+        "file"     .Page.File
     )}}
 {{ end }}
 

--- a/layouts/_shortcodes/kbd.html
+++ b/layouts/_shortcodes/kbd.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     ) -}}
     {{- $error = $args.err -}}
@@ -27,7 +27,7 @@
         "partial"  "shortcodes/kbd.html" 
         "msg"      "Invalid arguments"
         "details"  (slice "argument 'text': expected value")
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     ) -}}
     {{- $error = true -}}

--- a/layouts/_shortcodes/link.html
+++ b/layouts/_shortcodes/link.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     ) -}}
 {{- end -}}

--- a/layouts/_shortcodes/mark.html
+++ b/layouts/_shortcodes/mark.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/nav-item.html
+++ b/layouts/_shortcodes/nav-item.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     ) -}}
 {{- end -}}

--- a/layouts/_shortcodes/nav.html
+++ b/layouts/_shortcodes/nav.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     ) -}}
 {{- end -}}

--- a/layouts/_shortcodes/navbar.html
+++ b/layouts/_shortcodes/navbar.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error := $args.err }}

--- a/layouts/_shortcodes/persona.html
+++ b/layouts/_shortcodes/persona.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/persona.html
+++ b/layouts/_shortcodes/persona.html
@@ -31,8 +31,9 @@
 
 {{/* Main code */}}
 {{- if not $error -}}
-    {{- partial "assets/persona.html" (dict 
-        "path"      $args.path 
+    {{- partial "assets/persona.html" (dict
+        "page"      .Page
+        "path"      $args.path
         "class"     $args.class 
         "color"     $args.color
         "title"     $args.title

--- a/layouts/_shortcodes/release.html
+++ b/layouts/_shortcodes/release.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/spinner.html
+++ b/layouts/_shortcodes/spinner.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/sub.html
+++ b/layouts/_shortcodes/sub.html
@@ -11,7 +11,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/sup.html
+++ b/layouts/_shortcodes/sup.html
@@ -11,7 +11,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/table.html
+++ b/layouts/_shortcodes/table.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{- end -}}

--- a/layouts/_shortcodes/testimonial.html
+++ b/layouts/_shortcodes/testimonial.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/timeline.html
+++ b/layouts/_shortcodes/timeline.html
@@ -16,7 +16,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/toast.html
+++ b/layouts/_shortcodes/toast.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/tooltip.html
+++ b/layouts/_shortcodes/tooltip.html
@@ -14,7 +14,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = $args.err }}

--- a/layouts/_shortcodes/video.html
+++ b/layouts/_shortcodes/video.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}

--- a/layouts/_shortcodes/vimeo.html
+++ b/layouts/_shortcodes/vimeo.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}

--- a/layouts/_shortcodes/youtube.html
+++ b/layouts/_shortcodes/youtube.html
@@ -12,7 +12,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($args.errmsg | append $args.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -19,9 +19,6 @@
 {{- $fullCover := or (or (and .IsHome .Site.Params.home.fullCover) .Page.Params.fullCover) .Site.Params.main.footerBelowFold }}
 {{- $.Scratch.Set "fullCover" $fullCover -}}
 
-{{- /* Define main breakpoint */ -}}
-{{- $.Scratch.Set "breakpoint" (partialCached "utilities/GetBreakpoint.html" .) }}
-
 {{- /* Define page metadata */ -}}
 {{- $.Scratch.Set "metadata" (partial "utilities/GetMetadata.html" .) }}
 
@@ -33,10 +30,6 @@
 
 {{- /* Prepare content blocks and establish overlay mode */ -}}
 {{ $overlayMode := $.Scratch.Get "overlayMode" }}
-
-{{- /* Define base URL */ -}}
-{{ $lang := site.Language.Lang }}
-{{ $.Scratch.Set "baseURL" (strings.TrimSuffix (printf "%s/" $lang) site.Home.RelPermalink) }}
 
 <!doctype html>
 <html lang="{{ .Site.Language.Lang }}" class="no-js">

--- a/layouts/docs/all.html
+++ b/layouts/docs/all.html
@@ -23,8 +23,6 @@
             <div class="col-12 col-{{ $breakpoint.current }}-9 col-{{ $breakpoint.next }}-8 mb-5">
                 {{/* Render the defined content blocks, using the default articles element as fallback for list pages */}}
                 {{ if .Params.content_blocks }}
-                    {{/* The scratch value below is deprecated, kept for module version skew */}}
-                    {{- $.Scratch.Set "blocks_embed" true -}}
                     {{- partial "page/blocks.html" (dict "page" . "embed" true) -}}
                 {{ else if eq .Kind "section" }}
                     {{ $.Scratch.Set "articlesParams" (dict


### PR DESCRIPTION
## Render-once backlog — minor-safe cleanup (3 commits)

1. **Seeds + dead plumbing** — deletes the `breakpoint` and `baseURL` Scratch seeds from
   baseof (zero readers remain anywhere, grep-proven incl. vendored modules; one residual
   `stylesheet.html` reader migrated to `GetBaseURL`); retires the paginator Store plumbing
   (writer + dead OpenGraph branch — Q1 disproven during the program); drops the
   `blocks_embed` Scratch.Set in `docs/all.html` (embed prop threaded end-to-end since
   v2.2.4).
2. **D7-hinode diagnostics sweep** — 97 warning-attribution refs switched to the intrinsic
   page (`(or $args.page page).File` / `.Page.File`), 16 left global with per-site reasons,
   7 already intrinsic.
3. **Persona page threading** — the real cause behind the `warn-missing-page-argument`
   suppression (not the args engine): `_shortcodes/persona.html` didn't pass `page` and the
   partial only derived it from `path`, so `thumbnail=`-only usage (mod-docs' example) fed a
   nil page into image.html. Fixed at both drops + `persona.yml` gains the optional `page`
   arg; the exampleSite `ignoreErrors` suppression is REMOVED — the warning no longer exists.

### Gate
Stock ×2 + candidate ×2 (per-commit and final): fully byte-identical run-vs-run AND vs stock
(no allowlist); `check-build-determinism.sh` PASS (independently re-run by the driver);
98/26/24; 0 ERROR; WARN set identical (persona warning gone + suppression removed net to
zero); sprite audit 0 dangling across 3554 use-refs; `pnpm test` green. Residual-reader grep
for every retired mechanism: zero hits.

Major-bound cleanup (Scratch dual-writes, purgeHTMLComments removal, warn→error) is parked in
the v7 checklist beside the program register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)