### PR TITLE
fix: keep the RSS <language> element working on Hugo < 0.158

### DIFF
--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -50,7 +50,7 @@
 		<link>{{ .Permalink }}</link>
 		<description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
 		<generator>Hugo</generator>
-		<language>{{ site.Language.Locale }}</language>
+		<language>{{ if le (hugo.Version.Compare "0.158.0") 0 }}{{ site.Language.Locale }}{{ else }}{{ site.Language.LanguageCode }}{{ end }}</language>
 		{{ with $authorEmail }}
 			<managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>
 		{{ end }}


### PR DESCRIPTION
## What

`site.Language.Locale` was added in Hugo **0.158** (when `languageCode` was deprecated in its
favour). `layouts/rss.xml` uses it unconditionally, so on **Hugo 0.146–0.157** every RSS render
fails with:

```
rss.xml:53:15: executing "rss.xml" at <site>: can't evaluate field Locale in type *langs.Language
```

Version-gate it: `site.Language.Locale` on Hugo ≥ 0.158, `site.Language.LanguageCode` on older
Hugo. `hugo.Version.Compare "0.158.0"` is a semantic (not string) version test.

```diff
-<language>{{ site.Language.Locale }}</language>
+<language>{{ if le (hugo.Version.Compare "0.158.0") 0 }}{{ site.Language.Locale }}{{ else }}{{ site.Language.LanguageCode }}{{ end }}</language>
```

## Why

Restores the theme's stated Hugo compatibility floor. Found while validating Hugo 0.147.6
support for the starter template.

## Evidence

- exampleSite RSS renders with **no error on Hugo 0.147.6 and 0.164.0**; `<language>` = `en-us`
  on 0.164, the language code on 0.147.6.

**Held** for review. (Separately: the search-index `templates.Defer` leak on Hugo < 0.164 is
fixed in gethinode/mod-flexsearch#310; the two together restore hinode-v3.6.0 rendering on Hugo
0.147.6+. A postcss-transform failure seen locally on 0.147.6 traces to a broken pnpm `.bin/postcss`
shim on the dev machine — not a theme defect.)