### PR TITLE
fix: prevent sidebar menu recursion when unpublished pages enter the hierarchy

### DIFF
--- a/exampleSite/content/en/browserconfig.md
+++ b/exampleSite/content/en/browserconfig.md
@@ -3,4 +3,5 @@ draft: false
 outputs:
 - xml
 url: browserconfig.xml
+excludeFromSidebar: true
 ---

--- a/exampleSite/content/en/cookies.md
+++ b/exampleSite/content/en/cookies.md
@@ -2,7 +2,7 @@
 title: Cookie Policy
 description: Cookie policy of gethinode.com
 date: 2024-09-19
-layout: docs
+type: docs
 ---
 <!-- markdownlint-disable MD036 -->
 *Effective Date 19-Sep-2024*

--- a/exampleSite/content/en/privacy.md
+++ b/exampleSite/content/en/privacy.md
@@ -2,7 +2,7 @@
 title: Privacy Policy
 description: Privacy policy of gethinode.com
 date: 2024-09-19
-layout: docs
+type: docs
 ---
 <!-- markdownlint-disable MD036 -->
 *Effective Date 19-Sep-2024*

--- a/layouts/_partials/assets/helpers/sidebar-menu-entry.html
+++ b/layouts/_partials/assets/helpers/sidebar-menu-entry.html
@@ -6,6 +6,7 @@
     - grouped: Dictionary mapping parent paths to children slices
     - sortField: Field to sort children by (e.g., "title", "date", "weight")
     - reverse: Whether to reverse sort order (default: false)
+    - seen: Slice of ancestor permalinks in the current walk, used as cycle guard (internal)
 
     Returns: Menu entry dict with title and pages (optional array of nested entries)
 */}}
@@ -14,6 +15,7 @@
 {{- $grouped := .grouped -}}
 {{- $sortField := .sortField | default "title" -}}
 {{- $reverse := .reverse | default false -}}
+{{- $seen := .seen | default slice -}}
 
 {{- /* Create menu entry with title and absolute link */ -}}
 {{- /* Include the full RelPermalink; sidebar will recognize leading "/" as absolute */ -}}
@@ -21,6 +23,13 @@
 
 {{- /* Get children from grouped hierarchy */ -}}
 {{- $children := index $grouped $page.RelPermalink | default slice -}}
+{{- /* Guard against cycles: the grouped map keys pages by permalink, so any permalink collision
+    (or malformed hierarchy) could make a page its own ancestor and recurse forever */ -}}
+{{- if in $seen $page.RelPermalink -}}
+    {{- warnf "Sidebar hierarchy contains a cycle at %q; skipping its children" $page.RelPermalink -}}
+    {{- $children = slice -}}
+{{- end -}}
+{{- $seen = $seen | append $page.RelPermalink -}}
 {{- if $children -}}
     {{- /* Sort children using Hugo's page collection methods */ -}}
     {{- if eq $sortField "title" -}}
@@ -48,7 +57,7 @@
     {{- /* Recursively build nested menu entries */ -}}
     {{- $pages := slice -}}
     {{- range $children -}}
-        {{- $childEntry := partial "assets/helpers/sidebar-menu-entry" (dict "page" . "grouped" $grouped "sortField" $sortField "reverse" $reverse) -}}
+        {{- $childEntry := partial "assets/helpers/sidebar-menu-entry" (dict "page" . "grouped" $grouped "sortField" $sortField "reverse" $reverse "seen" $seen) -}}
         {{- $pages = $pages | append $childEntry -}}
     {{- end -}}
     {{- $entry = merge $entry (dict "pages" $pages) -}}

--- a/layouts/_partials/assets/live-pages.html
+++ b/layouts/_partials/assets/live-pages.html
@@ -119,6 +119,11 @@
                 {{- $grouped := dict -}}
                 {{- $rootPages := slice -}}
 
+                {{- /* Exclude unpublished pages (e.g. cascaded `build.render` "never"): their
+                    RelPermalink is empty, so they cannot be linked and all of them collapse into a
+                    single "" key that turns the hierarchy into a cyclic graph */ -}}
+                {{- $pages = where $pages "RelPermalink" "!=" "" -}}
+
                 {{- range $page := $pages -}}
                     {{- if $page.Parent -}}
                         {{- $parentPath := $page.Parent.RelPermalink -}}


### PR DESCRIPTION
> **HELD** — do not merge without maintainer review. Opened with evidence by the migration driver session; blocks the gethinode.com v3.2.2 → v3.6.0 migration.

## Symptom

Building gethinode.com against hinode v3.6.0 crashes with `maximum template call stack size exceeded` in `assets/helpers/sidebar-menu-entry.html` while rendering any root-level page with `type: docs` (e.g. `privacy.md`, `cookies.md`).

## Root cause

The section-grouped sidebar (`assets/live-pages.html`, `group-by=section`) keys its parent→children map by `RelPermalink`. Pages that are never rendered — the `_modals` branch cascades `build.render: never`, and mod-flexsearch's content adapter adds `/_modals/search/search` — all have an **empty** `RelPermalink`, so distinct pages collapse into a single `""` key:

- `/_modals` (section) becomes a child of home (`/` → `""`), and
- the modal search page becomes a child of `""` (`""` → `""`) — a self-loop.

A root-level docs page canonicalizes the sidebar root to **home** (`sidebar-cached.html` → `FirstSection`), so the collection spans `_modals` and the recursive menu walk loops forever. The exampleSite never hit it because its policy pages declare `layout: docs`, which no longer resolves to any template in the v3 lookup order — they silently render as plain single pages (fixed here too).

## Fix (two layers)

1. **`live-pages.html`** — drop pages with an empty `RelPermalink` from the grouped hierarchy; they cannot be linked in a sidebar anyway. This removes the cycle at its source.
2. **`sidebar-menu-entry.html`** — thread a `seen` slice of ancestor permalinks; on a repeat visit, warn (`Sidebar hierarchy contains a cycle at …`) and truncate instead of overflowing the template stack. Defense for any future malformed hierarchy.

## Regression coverage

`exampleSite/content/en/{privacy,cookies}.md` switch `layout: docs` → `type: docs` (matching gethinode.com), which restores their intended docs layout **and** makes the exampleSite exercise the exact crashing shape: unfixed, `hugo -s exampleSite` overflows the stack; fixed, it builds green. `browserconfig.md` gains `excludeFromSidebar: true` (its custom XML `url` is not resolvable as a page reference from a sidebar).

## Evidence (Hugo 0.164.0 extended)

- Unfixed + `type: docs` policy pages: `ERROR … sidebar-menu-entry.html:51 … maximum template call stack size exceeded`.
- Fix layer 1 only: exampleSite + gethinode.com repro both build green (gethinode.com: `Total in 6938 ms`).
- Fix layer 2 only (filter disabled): no stack overflow; `WARN Sidebar hierarchy contains a cycle at ""; skipping its children` and graceful degradation.
- Both layers: `pnpm run build:example` green, `Total in 6357 ms`; rendered `/en/privacy/` carries the full docs sidebar tree.
- Diagnostic method: dumped every `parent→child` RelPermalink edge from the grouping and ran a cycle finder — the only cycle is the `""` self-loop from the `_modals` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)