### PR TITLE
fix: script pipeline correctness batch

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -114,7 +114,6 @@ home = ["HTML", "RSS", "REDIR", "netlify", "server", "searchindex"]
 
 [minify]
   [minify.tdewolff.js]
-    keepVarNames = true
     precision = 0
     version = 2022
   [minify.tdewolff.html]

--- a/data/structures/live-pages.yml
+++ b/data/structures/live-pages.yml
@@ -77,8 +77,9 @@ arguments:
     comment:
       If set, groups the results by the specified field. Currently only supports
       grouping by section.
-    values:
-      - section
+    options:
+      values:
+        - section
     release: v2.0.0
   include-list:
     type: bool

--- a/data/structures/scripts.yml
+++ b/data/structures/scripts.yml
@@ -19,7 +19,8 @@ arguments:
       loaded asynchronously. Optional scripts are loaded individually on the
       pages that require them. They use the synchronization method as defined
       in their containing module.
-    values:
-      - critical
-      - core
-      - optional
+    options:
+      values:
+        - critical
+        - core
+        - optional

--- a/layouts/_partials/footer/scripts.html
+++ b/layouts/_partials/footer/scripts.html
@@ -193,7 +193,7 @@
                     "localize"       $localize
                     "skipTemplate"   $skipTemplate
                     "absoluteURL"    $absoluteURL
-                    "state"          (cond (eq $args.type "critical") "immediate" "async")
+                    "state"          (cond (eq $args.type "critical") "immediate" "defer")
                 )}} 
             {{- end -}}
         {{- end -}}

--- a/layouts/_partials/utilities/InitModules.html
+++ b/layouts/_partials/utilities/InitModules.html
@@ -17,7 +17,7 @@
         {{ else if eq $integration "optional" }}
             {{ $optional = $optional | append $key }}
         {{ else if $integration }}
-            {{ warnf "Unrecognized module integration setting: %s" $integration }}
+            {{ errorf "Module '%s' has an unrecognized integration value '%v'; use one of: critical, core, optional" $key $integration }}
         {{ end }}
         
         {{ if eq (index $mod "excludeSCSS") true }}

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -9,7 +9,6 @@
     <noscript><meta http-equiv="refresh" content="0; url={{ .Permalink }}"></noscript>
     {{ if and page site.Params.main.enableLanguageSelectionStorage }} 
       {{- partial "footer/scripts.html" (dict "page" page "type" "critical") -}}
-      {{- partial "footer/scripts.html" (dict "page" page "type" "functional") -}}
     {{ else }}
       <script src='{{ partial "utilities/GetStaticURL" (dict "url" "js/alias.js") }}'></script>
     {{ end }}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -35,7 +35,6 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
     <head>
         {{- partial "footer/scripts.html" (dict "page" . "type" "critical") -}}
-        {{- partial "footer/scripts.html" (dict "page" . "type" "functional") -}}
         {{ block "head" . }}{{ end -}}
     </head>
 


### PR DESCRIPTION
## Summary

Correctness batch from the js-pipeline program (slice J1); self-contained, no dependency on other program PRs.

- **Remove dead `functional` script calls** in `baseof.html` and `alias.html` — `functional` is not a legal bundle type (critical/core/optional); both calls were silent no-ops on every page
- **Close the validation gap that hid them**: `data/structures/scripts.yml` (and `live-pages.yml`, found by a full 66-file audit) declared `values:` at argument level where the Args engine only checks `options.values`; invalid select values now fail validation (proof: a bogus `type` produces `unexpected value 'bogus'` errors)
- **Core bundle `async` → `defer`**: predictable execution order relative to DOM parse and the deferred optional bundles; critical stays immediate
- **InitModules: unrecognized `integration` values now fail the build** (was: warnf + silent drop of the module from all bundles)
- **Drop `keepVarNames` from the JS minify config**. Note: currently re-imposed by mod-katex's config ([mod-katex#218](https://github.com/gethinode/mod-katex/pull/218) removes it there); once that lands, identifier mangling shrinks the core bundle −25.6% raw / −14.2% gzip (measured)

## Evidence

- exampleSite: 0 ERROR, WARN parity with stock, page counts 98/26/24, determinism script PASS
- HTML diff vs stock: only the `async`→`defer` attribute on core-bundle tags (verified pairwise-identical after normalizing that token)
- Hugo 0.147.6 compat build: zero errors, identical page counts

Part of the js-pipeline program (register on gethinode.com `develop`). [hinode js/j4-esm-adoption] stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)