### PR TITLE
fix: accessibility, caching, and font-loading improvements from a Lighthouse audit

### DIFF
--- a/assets/scss/components/_blockquote.scss
+++ b/assets/scss/components/_blockquote.scss
@@ -6,6 +6,7 @@
 
 .blockquote-alert {
     --bs-blockquote-alert-color: #{$secondary};
+    --bs-blockquote-alert-heading-color: var(--#{$prefix}secondary-color);
 
     border-left: 0.3rem solid;
     border-color: var(--bs-blockquote-alert-color);
@@ -18,27 +19,36 @@
 
 .blockquote-alert-heading {
     font-weight: bold;
-    color: var(--bs-blockquote-alert-color);
+
+    // Keep the vivid accent on the border, but render the heading text with the
+    // accessible '-text-emphasis' tint so it meets WCAG contrast on the body background
+    // (raw theme accents such as warning/info/success fail 4.5:1 as foreground text).
+    color: var(--bs-blockquote-alert-heading-color);
 }
 
 .blockquote-alert-caution {
     --bs-blockquote-alert-color: var(--#{$prefix}danger);
+    --bs-blockquote-alert-heading-color: var(--#{$prefix}danger-text-emphasis);
 }
 
 .blockquote-alert-important {
     --bs-blockquote-alert-color: var(--#{$prefix}primary);
+    --bs-blockquote-alert-heading-color: var(--#{$prefix}primary-text-emphasis);
 }
 
 .blockquote-alert-note {
     --bs-blockquote-alert-color: var(--#{$prefix}info);
+    --bs-blockquote-alert-heading-color: var(--#{$prefix}info-text-emphasis);
 }
 
 .blockquote-alert-tip {
     --bs-blockquote-alert-color: var(--#{$prefix}success);
+    --bs-blockquote-alert-heading-color: var(--#{$prefix}success-text-emphasis);
 }
 
 .blockquote-alert-warning {
     --bs-blockquote-alert-color: var(--#{$prefix}warning);
+    --bs-blockquote-alert-heading-color: var(--#{$prefix}warning-text-emphasis);
 }
 
 .blockquote-alert a.btn-link {

--- a/assets/scss/components/_button.scss
+++ b/assets/scss/components/_button.scss
@@ -8,8 +8,15 @@
 }
 
 .btn-social {
+    // Keep the interactive area at least 24x24 CSS px to satisfy WCAG 2.5.8 (Target Size Minimum),
+    // even though these icon buttons are rendered with 'p-0'. The icon stays centered and unchanged.
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    min-height: 1.5rem;
     background-color: transparent;
-    
+
     --bs-btn-bg: transparent;
     --bs-btn-border-width: none;
     --bs-btn-color: var(--bs-secondary);

--- a/assets/scss/theme/fonts.scss
+++ b/assets/scss/theme/fonts.scss
@@ -10,7 +10,7 @@
 
 /* inter-200 - latin */
 @font-face {
-    font-display: block; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+    font-display: swap; /* Show fallback text immediately and swap in Inter once loaded, avoiding invisible text (FOIT) on the critical render path. See https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display */
     font-family: 'Inter';
     font-style: normal;
     font-weight: 200;
@@ -23,7 +23,7 @@
   }
   /* inter-300 - latin */
   @font-face {
-    font-display: block; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+    font-display: swap; /* Show fallback text immediately and swap in Inter once loaded, avoiding invisible text (FOIT) on the critical render path. See https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display */
     font-family: 'Inter';
     font-style: normal;
     font-weight: 300;
@@ -36,7 +36,7 @@
   }
   /* inter-regular - latin */
   @font-face {
-    font-display: block; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+    font-display: swap; /* Show fallback text immediately and swap in Inter once loaded, avoiding invisible text (FOIT) on the critical render path. See https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display */
     font-family: 'Inter';
     font-style: normal;
     font-weight: 400;
@@ -49,7 +49,7 @@
   }
   /* inter-600 - latin */
   @font-face {
-    font-display: block; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+    font-display: swap; /* Show fallback text immediately and swap in Inter once loaded, avoiding invisible text (FOIT) on the critical render path. See https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display */
     font-family: 'Inter';
     font-style: normal;
     font-weight: 600;

--- a/data/server.toml
+++ b/data/server.toml
@@ -17,10 +17,14 @@
             fullscreen=(), \
             payment=() \
             """
+        # 'no-store' is intentionally omitted: it blocks the browser back/forward cache and forces a
+        # full re-download of every response. 'must-revalidate' keeps content fresh (the browser
+        # revalidates and gets a cheap 304), which is safe in dev and correct in production since
+        # Netlify invalidates cached responses on each deploy. See Netlify caching guidance:
+        # https://docs.netlify.com/build/caching/caching-overview/
         cache-control = """\
+            public, \
             max-age=0, \
-            no-cache, \
-            no-store, \
             must-revalidate \
             """
         Access-Control-Allow-Origin = "*"

--- a/exampleSite/config/_default/hugo.toml
+++ b/exampleSite/config/_default/hugo.toml
@@ -143,6 +143,6 @@ home = ["HTML", "RSS", "REDIR", "netlify", "server"]
     source = "static"
     target = "static"
   [[module.imports]]
-    path = "github.com/gethinode/mod-cookieyes/v2"
+    path = "github.com/gethinode/mod-cookieyes/v3"
   [[module.imports]]
     path = "github.com/gethinode/hinode/v3"

--- a/exampleSite/data/server.toml
+++ b/exampleSite/data/server.toml
@@ -17,10 +17,14 @@
             fullscreen=(), \
             payment=() \
             """
+        # 'no-store' is intentionally omitted: it blocks the browser back/forward cache and forces a
+        # full re-download of every response. 'must-revalidate' keeps content fresh (the browser
+        # revalidates and gets a cheap 304), which is safe in dev and correct in production since
+        # Netlify invalidates cached responses on each deploy. See Netlify caching guidance:
+        # https://docs.netlify.com/build/caching/caching-overview/
         cache-control = """\
+            public, \
             max-age=0, \
-            no-cache, \
-            no-store, \
             must-revalidate \
             """
         Access-Control-Allow-Origin = "*"

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cloudcannon/bookshop/hugo/v3 v3.18.5 // indirect
 	github.com/gethinode/mod-blocks/v2 v2.2.5 // indirect
 	github.com/gethinode/mod-bootstrap-icons/v2 v2.0.2 // indirect
-	github.com/gethinode/mod-cookieyes/v2 v2.2.6 // indirect
+	github.com/gethinode/mod-cookieyes/v3 v3.1.0 // indirect
 	github.com/gethinode/mod-docs v1.15.4 // indirect
 	github.com/gethinode/mod-fontawesome/v6 v6.1.1 // indirect
 	github.com/twbs/icons v1.13.1 // indirect

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -6,8 +6,8 @@ github.com/gethinode/mod-blocks/v2 v2.2.5 h1:8glKSX7OENSgbRAp+Bc1JL68Ix3DSWcHWh5
 github.com/gethinode/mod-blocks/v2 v2.2.5/go.mod h1:1a4A2RrNSEoqgUjJoNPc2T+JtfPe0GvjHNrxjXauWCA=
 github.com/gethinode/mod-bootstrap-icons/v2 v2.0.2 h1:KTQBwRB/1zRO3aS61bH2NNl/uTzelDLFxDjWbrqVKFc=
 github.com/gethinode/mod-bootstrap-icons/v2 v2.0.2/go.mod h1:oWYYQyAQgOFwrWwBZ8V+ztMCE7XmNTFbcmh28GWO2IA=
-github.com/gethinode/mod-cookieyes/v2 v2.2.6 h1:/DQm8OYpms0On8wuosQER47TplVu/3z7MZHwbBKXCAg=
-github.com/gethinode/mod-cookieyes/v2 v2.2.6/go.mod h1:tULb7D7CoTycGUyL7ryqHJKaX11XuL2SN+XwP7/DI0Y=
+github.com/gethinode/mod-cookieyes/v3 v3.1.0 h1:wan8yGs1bmwrgdySWSCqDbkiAsbTn8nWogwI+qKH6Is=
+github.com/gethinode/mod-cookieyes/v3 v3.1.0/go.mod h1:nhLWDG1BCHAPXFdGYYbCrgFbm4XrSOyxbGlZZAeWJsM=
 github.com/gethinode/mod-docs v1.15.4 h1:8lkrhuxbg5+XfyW+e0f7XjnIUY9J+kF0IqT7aVNGUZY=
 github.com/gethinode/mod-docs v1.15.4/go.mod h1:ru1w0fHqFocjDIMV0dm40OwhBw5k4UncCS8iO/1S5kI=
 github.com/gethinode/mod-fontawesome/v6 v6.1.1 h1:k5Jy7nA+YfLZ9YqXH8hyaiw9wjAeOxNEUcnu6fynnJo=

--- a/layouts/_partials/assets/card.html
+++ b/layouts/_partials/assets/card.html
@@ -37,9 +37,13 @@
     {{- $class := .class }}
     {{- $fs := .fs | default "fs-lg-5 fs-6" }}
     {{- $linkIcon := .linkIcon -}}
+    {{- $label := .label -}}
 
     {{- if $href -}}
-        <a href="{{ $href }}" class="{{ if $color }}link-bg-{{ $color }}{{ else }}card-body-link{{ end }} stretched-link {{ $class }}">
+        <a href="{{ $href }}"
+            class="{{ if $color }}link-bg-{{ $color }}{{ else }}card-body-link{{ end }} stretched-link {{ $class }}"
+            {{- /* Give bare image/link cards an accessible name when they carry no visible text (WCAG link-name) */ -}}
+            {{- if and $label (not (or $title $links $description)) }} aria-label="{{ $label }}"{{ end }}>
             {{ if or $title $links }}
                 <p class="card-title {{ $fs }}">
                     {{- with $title }}{{ . | $page.RenderString }}{{ end }}
@@ -188,6 +192,9 @@
     {{- $iconStyle = "pb-3" -}}
 {{ end }}
 
+{{/* Capture an accessible name before body styles blank the title, so a bare image/stretched-link
+     card (no visible text) is never a nameless link (WCAG 'link-name'). */}}
+{{- $ariaLabel := or $args.alt $title -}}
 {{ $minimal := or (eq $args.bodyStyle "minimal") (eq $args.body "minimal") }}
 {{- if eq $args.orientation "none" }}{{ $thumbnail = "" }}{{ $icon = "" }}{{ end -}}
 {{- if or (eq $args.bodyStyle "title") (eq $args.body "title") }}{{ $description = "" }}{{ end -}}
@@ -268,6 +275,7 @@
                         {{- partial "inline/card-body.html" (dict
                             "page"        $renderPage
                             "owner"       $args.page
+                            "label"       $ariaLabel
                             "title"       (cond $minimal "" $title)
                             "href"        $href
                             "color"       $args.color
@@ -334,6 +342,7 @@
             {{- partial "inline/card-body.html" (dict
                 "page"        $renderPage
                 "owner"       $args.page
+                "label"       $ariaLabel
                 "title"       (cond $minimal "" $title)
                 "href"        $href
                 "color"       $args.color

--- a/layouts/_partials/assets/nav.html
+++ b/layouts/_partials/assets/nav.html
@@ -13,16 +13,16 @@
     {{ $wrap := .wrap }}
 
     <div id="dropdown-{{ $id }}" class="dropdown panel-dropdown {{ $class }}">
-    <a class="link-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+    <button type="button" class="link-secondary dropdown-toggle border-0 bg-transparent p-0" data-bs-toggle="dropdown" aria-expanded="false">
         {{ cond (gt (len $titles) 0) (index $titles 0) (T "sectionMenu") }}
-    </a>
+    </button>
         <ul class="dropdown-menu">
             {{- range $index, $item := $titles -}}
                 {{ $itemID := printf "%s-btn-%d" $id $index -}}
                 {{- $show := eq $index 0 -}}
                 <li>
-                    <a class="dropdown-item {{ if not $wrap }} text-nowrap{{ end }}{{ if $show }} active{{ end }}"
-                    data-link="#{{ $id }}-btn-{{ $index }}" type="button">{{ $item }}</a>
+                    <button class="dropdown-item {{ if not $wrap }} text-nowrap{{ end }}{{ if $show }} active{{ end }}"
+                    data-link="#{{ $id }}-btn-{{ $index }}" type="button">{{ $item }}</button>
                 </li>
             {{ end }}
         </ul>

--- a/layouts/_partials/footer/scripts.html
+++ b/layouts/_partials/footer/scripts.html
@@ -187,10 +187,22 @@
         {{- if in $modules $mod -}}
             {{- if or (index $cfg "local") (not hugo.IsServer) -}}
                 {{- with index $cfg "url" -}}
+                    {{/* Preconnect to the external script host so the DNS + TLS handshake overlaps
+                        earlier work on the critical path. Hosts are declared per-module via the
+                        'preconnect' parameter and only emitted for the critical (head) lane. No
+                        'crossorigin' — a plain <script src> reuses the anonymous-credentialled
+                        connection this hint opens. */}}
+                    {{- if eq $args.type "critical" -}}
+                        {{- with (index $cfg "preconnect") -}}
+                            {{- range $pc := (partial "utilities/ToStringSlice.html" .) -}}
+                                <link rel="preconnect" href="{{ $pc }}">
+                            {{- end -}}
+                        {{- end -}}
+                    {{- end -}}
                     {{- partial "templates/script.html" (dict
                         "link"     .
                         "category" (index $cfg "category")
-                        "state"    (index $cfg "state")) 
+                        "state"    (index $cfg "state"))
                     -}}
                 {{- end -}}
             {{- end -}}


### PR DESCRIPTION
## What

Generic theme improvements identified by a mobile Lighthouse audit of a Hinode site (homepage, a docs page, and an article). Only **theme-generic** findings are addressed here — site-specific items (a third-party consent script, an oversized hero GIF, per-site cache tuning) are tracked separately for a site-level sweep.

The audit showed strong baselines (TBT 0ms, CLS 0, Best-Practices 100). The wins concentrate in **accessibility (88→~100)**, **docs SEO (92→100)**, and **text-LCP / font loading**.

## Changes (one commit each)

| Commit | Lighthouse audit addressed |
|---|---|
| `perf: font-display swap for Inter` | font-display, LCP/FCP — the LCP element is text, so `font-display: block` (FOIT) sat on the critical path |
| `fix: drop no-store from default cache-control` | **bf-cache** — `no-store` blocked the back/forward cache and forced asset re-downloads; now `public, max-age=0, must-revalidate` per [Netlify guidance](https://docs.netlify.com/build/caching/caching-overview/) |
| `fix: button semantics for responsive nav dropdown` | **crawlable-anchors** (SEO) + **aria-allowed-attr** (a11y) — the responsive toggle/items were `<a>` without href; now `<button>`, matching the desktop variant |
| `fix: contrast on blockquote alert headings` | **color-contrast** — headings used the raw semantic accent as text; now the accessible `-text-emphasis` token (accent stays on the border) |
| `fix: 24px min tap target for social buttons` | **target-size** — `p-0` icon buttons were <24px; now a 24×24 hit area, icon unchanged |
| `fix: accessible name for image-only cards` | **link-name** — bare stretched-link cards with no visible text were nameless; now emit an `aria-label` from title/alt only when there's no visible text |
| `feat: preconnect for critical module hosts that declare it` | **uses-rel-preconnect** — modules can declare a `preconnect` host list; the critical (head) lane emits `<link rel=preconnect>` before the script. No-op unless a module opts in |

## Notes

- The `preconnect` mechanism pairs with gethinode/mod-cookieyes#207 (merged, **v3.1.0**), which declares `preconnect = ["https://cdn-cookieyes.com"]`. This PR also **bumps the exampleSite to mod-cookieyes v3.1.0** (a v2→v3 major bump; v3 adds Storage Access API support) so the feature is exercised end-to-end here — the exampleSite home page now emits `<link rel="preconnect" href="https://cdn-cookieyes.com">` in the head. The mechanism itself is still a no-op for any module that doesn't declare a `preconnect` host.
- The cache-control fix lives in `data/server.toml` (the default consumer sites inherit) and `exampleSite/data/server.toml` (this repo's own reference site). Verified it wins over the `mod-csp` base on module fallthrough, so sites without their own `data/server.toml` pick it up on the next build.
- **Deferred:** an `unsized-images` finding on a hero GIF — the image is a static asset that bypasses Hugo's pipeline, so intrinsic dimensions can't be read without pipeline surgery, and CLS is already 0. Better handled as content guidance (use a processable asset / video).

## Verification

- Production build of the exampleSite (`hugo -e production --gc --minify`) compiles and renders — no errors.
- Confirmed in built output: `font-display:swap` (×4, Inter), `<button>` nav toggle, `.btn-social{…min-width:1.5rem;min-height:1.5rem}`, `--bs-*-text-emphasis` heading colors, `aria-label` on previously-nameless cards, generated `netlify.toml`/`server.toml` emit `public, max-age=0, must-revalidate` with zero `no-store`, and `<link rel=preconnect>` emitted when a critical module declares one.
- `stylelint` clean on the changed SCSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
