### PR TITLE
fix: safelist component attribute selectors in reference purge config

### DIFF
--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -6,7 +6,20 @@ const purgecss = purgeCSSPlugin({
     const els = JSON.parse(content).htmlElements
     return [...(els.tags || []), ...(els.classes || []), ...(els.ids || [])]
   },
-  dynamicAttributes: ['aria-expanded', 'data-bs-theme', 'data-bs-main-theme', 'data-bs-theme-animate', 'data-transparent', 'role'],
+  dynamicAttributes: [
+    'aria-expanded',
+    'data-bs-theme',
+    'data-bs-main-theme',
+    'data-bs-theme-animate',
+    'data-transparent',
+    'role',
+    // Command component (components/_command.scss): prompt text rendered via
+    // `content: attr(data-prompt)` / `attr(data-continuation-prompt)` — the
+    // attributes only ever appear as CSS attribute selectors, never as
+    // classes/ids/tags, so hugo_stats.json cannot record them.
+    'data-prompt',
+    'data-continuation-prompt'
+  ],
   fontFace: false,
   safelist: {
     // Every entry below is a class PurgeCSS cannot see in hugo_stats.json because it is


### PR DESCRIPTION
hugo_stats.json never records attribute names, so PurgeCSS strips rules
written as attribute selectors (e.g. [data-prompt] / [data-continuation-prompt]
in the command component) unless they're in dynamicAttributes. Add every
attribute selector hinode's own SCSS uses so the reference config — which
downstream sites seed from — doesn't over-purge them.
