### PR TITLE
feat: read per-module script externals/globals from module config

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -320,3 +320,17 @@
     # lightbox.mjs is a plain ES module without template constructs; keep it on the
     # import lane of the js.Build bundle instead of the inline (templated) lane
     disableTemplate = true
+
+# UMD distributions do not register their window global when bundled by esbuild;
+# expose the documented global through the bundle entry (see footer/scripts.html).
+[modules.bootstrap]
+    [modules.bootstrap.globals]
+        "js/modules/bootstrap/bootstrap.bundle.js" = "bootstrap"
+
+# The flexsearch UMD distribution does not register its window global when bundled
+# by esbuild and its Node-guarded require (worker_threads) never executes in
+# browsers; declare both so footer/scripts.html can wire them up generically.
+[modules.flexsearch]
+    externals = ["worker_threads"]
+    [modules.flexsearch.globals]
+        "js/modules/flexsearch/flexsearch.bundle.min.js" = "FlexSearch"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -321,16 +321,6 @@
     # import lane of the js.Build bundle instead of the inline (templated) lane
     disableTemplate = true
 
-# UMD distributions do not register their window global when bundled by esbuild;
-# expose the documented global through the bundle entry (see footer/scripts.html).
-[modules.bootstrap]
-    [modules.bootstrap.globals]
-        "js/modules/bootstrap/bootstrap.bundle.js" = "bootstrap"
-
-# The flexsearch UMD distribution does not register its window global when bundled
-# by esbuild and its Node-guarded require (worker_threads) never executes in
-# browsers; declare both so footer/scripts.html can wire them up generically.
-[modules.flexsearch]
-    externals = ["worker_threads"]
-    [modules.flexsearch.globals]
-        "js/modules/flexsearch/flexsearch.bundle.min.js" = "FlexSearch"
+# mod-bootstrap (>= v1.4.0) and mod-flexsearch (>= v5.2.0) declare their own
+# script globals/externals via the module-config convention (see
+# footer/scripts.html); hinode no longer needs to duplicate them here.

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.19
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0 // indirect
 	github.com/airbnb/lottie-web v5.13.0+incompatible // indirect
-	github.com/gethinode/mod-bootstrap v1.3.7 // indirect
+	github.com/gethinode/mod-bootstrap v1.4.0 // indirect
 	github.com/gethinode/mod-csp v1.0.12 // indirect
-	github.com/gethinode/mod-flexsearch/v5 v5.1.1 // indirect
+	github.com/gethinode/mod-flexsearch/v5 v5.2.0 // indirect
 	github.com/gethinode/mod-fontawesome/v6 v6.1.1 // indirect
 	github.com/gethinode/mod-google-analytics/v2 v2.0.4 // indirect
 	github.com/gethinode/mod-katex v1.1.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,12 @@ github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0 h1:4+bB2o
 github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/airbnb/lottie-web v5.13.0+incompatible h1:plBV5Uq/F1kK0EC61Hr0cBGReI9OgUfd/pp0baoDX8o=
 github.com/airbnb/lottie-web v5.13.0+incompatible/go.mod h1:nTss557UK9FGnp8QYlCMO29tjUHwbdAHG/DprbGfHGE=
-github.com/gethinode/mod-bootstrap v1.3.7 h1:rbjOg//q7dbsM+TkDQLsyk9LKv93D1RUjtcSkvV55UU=
-github.com/gethinode/mod-bootstrap v1.3.7/go.mod h1:CxrYCFzKtBMz3YWG5i/d5jHKCgvUo60NFcCmz2mxCjQ=
+github.com/gethinode/mod-bootstrap v1.4.0 h1:tvcpK574YoLtSSN8KkICWVT07Jdust6ppVDj8R6Zuh0=
+github.com/gethinode/mod-bootstrap v1.4.0/go.mod h1:CxrYCFzKtBMz3YWG5i/d5jHKCgvUo60NFcCmz2mxCjQ=
 github.com/gethinode/mod-csp v1.0.12 h1:6CaIH3IBn92lcwMFdYPmmWsPKq+VZ6n9Po8FI26jLJc=
 github.com/gethinode/mod-csp v1.0.12/go.mod h1:Nb22QMicoUHgZQUKP5TCgVrSI8K3KU7jLuLBShmotjg=
-github.com/gethinode/mod-flexsearch/v5 v5.1.1 h1:x1dnOMV1fLBzpWqPQYPnn8zDXN0bcdD16qAcIzsWD/s=
-github.com/gethinode/mod-flexsearch/v5 v5.1.1/go.mod h1:bo51LbCcYROomghgAWpH3w6EYSe8ZtdqrPSB6C/DZaA=
+github.com/gethinode/mod-flexsearch/v5 v5.2.0 h1:4v22TTZefDcwUkwlL1kPkS3IZ2ENax5t+bx0n8pWHWY=
+github.com/gethinode/mod-flexsearch/v5 v5.2.0/go.mod h1:bo51LbCcYROomghgAWpH3w6EYSe8ZtdqrPSB6C/DZaA=
 github.com/gethinode/mod-fontawesome/v6 v6.1.1 h1:k5Jy7nA+YfLZ9YqXH8hyaiw9wjAeOxNEUcnu6fynnJo=
 github.com/gethinode/mod-fontawesome/v6 v6.1.1/go.mod h1:875OBk5te+KBJmr0PdSkFcduYnsKCuHWfcaqChh9NGo=
 github.com/gethinode/mod-google-analytics/v2 v2.0.4 h1:ONEUjhfVR6p+Y/XyU3BUGXZy4+HAkJvGo+mr24ugklY=

--- a/layouts/_partials/footer/scripts.html
+++ b/layouts/_partials/footer/scripts.html
@@ -235,9 +235,12 @@
                 {{- with $templated }}{{ $enableTemplate = printf "{%s}" (delimit . ",") }}{{ end -}}
 
                 {{/* UMD distributions do not register their window global when bundled by
-                    esbuild; expose the documented globals through the bundle entry. The
-                    flexsearch distribution requires a worker_threads external (its
-                    Node-guarded require never executes in browsers). */}}
+                    esbuild; a module exposes its documented global(s) through the bundle
+                    entry by declaring 'globals' in its own module config. A module whose
+                    UMD distribution guards a require behind a Node-only code path (never
+                    executed in browsers) declares that path via 'externals' so esbuild
+                    does not try to resolve it. Both are read generically from each active
+                    module's config rather than hardcoded per module here. */}}
                 {{- $globals := dict -}}
                 {{- $externals := slice -}}
                 {{- $params := dict -}}
@@ -253,12 +256,10 @@
                         "copyToClipboard" (i18n "copyToClipboard")
                         "webshare"        (site.Params.sharing.webshare | default false)
                     -}}
-                    {{- if in $val "bootstrap" -}}
-                        {{- $globals = merge $globals (dict "js/modules/bootstrap/bootstrap.bundle.js" "bootstrap") -}}
-                    {{- end -}}
-                    {{- if in $val "flexsearch" -}}
-                        {{- $globals = merge $globals (dict "js/modules/flexsearch/flexsearch.bundle.min.js" "FlexSearch") -}}
-                        {{- $externals = $externals | append "worker_threads" -}}
+                    {{- range $val -}}
+                        {{- $modconfig := index $config.modules . -}}
+                        {{- with $modconfig.globals -}}{{ $globals = merge $globals . }}{{- end -}}
+                        {{- range ($modconfig.externals | default slice) -}}{{ $externals = $externals | append . }}{{- end -}}
                     {{- end -}}
                 {{- end -}}
 


### PR DESCRIPTION
Replace the hardcoded bootstrap/flexsearch globals+externals blocks in
footer/scripts.html with a generic loop that reads modules.<name>.globals
and modules.<name>.externals from each active module's config. bootstrap
and flexsearch now declare theirs in hinode's own config; any module
(e.g. mod-hanko for hanko-elements.min.mjs) can declare an esbuild
external without a hinode change or a downstream scripts.html override.
