### PR TITLE
feat: assemble script globals as an array of {path, name} tables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gethinode/mod-lottie/v3 v3.0.4 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.4 // indirect
 	github.com/gethinode/mod-simple-datatables/v4 v4.1.0 // indirect
-	github.com/gethinode/mod-utils/v6 v6.7.0 // indirect
+	github.com/gethinode/mod-utils/v6 v6.8.0 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/gethinode/mod-simple-datatables/v4 v4.1.0 h1:AtEtLH9RoAEIpElg0k6UkVlH
 github.com/gethinode/mod-simple-datatables/v4 v4.1.0/go.mod h1:jRHoX20bUiaVg7UtKzMjfHQjd5M6WZ8hAeVqA3TKwTA=
 github.com/gethinode/mod-utils/v6 v6.7.0 h1:DxqKUb13/6ydcntGIrUj1YD892VwarB8zGj+77CeUwM=
 github.com/gethinode/mod-utils/v6 v6.7.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
+github.com/gethinode/mod-utils/v6 v6.8.0 h1:Rz/6DlPKVW0791jSsobxx4I4pKQ38H4JOEeOV+GeRzU=
+github.com/gethinode/mod-utils/v6 v6.8.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 h1:QDKcU3q39lFGzdVwM6kgCGnW3ibbMfYIi0Rwl62iJpo=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0/go.mod h1:5GdMfPAXzbA2gXBqTjC6l27kioSYzHlqDMh0+wyx7sU=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=

--- a/layouts/_partials/footer/scripts.html
+++ b/layouts/_partials/footer/scripts.html
@@ -241,7 +241,7 @@
                     executed in browsers) declares that path via 'externals' so esbuild
                     does not try to resolve it. Both are read generically from each active
                     module's config rather than hardcoded per module here. */}}
-                {{- $globals := dict -}}
+                {{- $globals := slice -}}
                 {{- $externals := slice -}}
                 {{- $params := dict -}}
                 {{- if eq $args.type "critical" -}}
@@ -258,7 +258,15 @@
                     -}}
                     {{- range $val -}}
                         {{- $modconfig := index $config.modules . -}}
-                        {{- with $modconfig.globals -}}{{ $globals = merge $globals . }}{{- end -}}
+                        {{/* globals is an array of {path, name} tables; a legacy path-keyed
+                            map is still accepted (older modules) and normalized to the same shape */}}
+                        {{- with $modconfig.globals -}}
+                            {{- if reflect.IsMap . -}}
+                                {{- range $path, $name := . -}}{{- $globals = $globals | append (dict "path" $path "name" $name) -}}{{- end -}}
+                            {{- else -}}
+                                {{- range . -}}{{- $globals = $globals | append . -}}{{- end -}}
+                            {{- end -}}
+                        {{- end -}}
                         {{- range ($modconfig.externals | default slice) -}}{{ $externals = $externals | append . }}{{- end -}}
                     {{- end -}}
                 {{- end -}}


### PR DESCRIPTION
## Summary

The generic script-globals reader (#2063) keyed each module's `globals` by asset **path** and merged them into a map. Hugo lowercases TOML config keys, so a path-keyed map silently breaks for **capitalized** bundle filenames (e.g. GSAP's `ScrollTrigger.js`). Only all-lowercase names (bootstrap, flexsearch) worked.

This builds the globals argument as a **slice of `{path, name}`** appended from each active module's declared `[[modules.<name>.globals]]` entries, so the path is carried as a case-preserved value. Pairs with mod-utils v6.8.0, whose `bundlev3.html` consumes the array-of-tables form.

## Backward compatibility

A legacy path-keyed **map** declaration is still accepted (via `reflect.IsMap`) and normalized to the same shape, so **already-released map-format modules keep working** under the new reader — no forced downstream bump. Verified: a build with released map-format mod-bootstrap v1.4.0 / mod-flexsearch v5.2.0 injects `window.bootstrap` + `window.FlexSearch` alongside array-format `window.gsap` / `window.ScrollTrigger` / `window.SplitText`.

## Verification

- hinode exampleSite builds clean (dev) with mod-utils v6.8.0.
- Proven end-to-end on a real GSAP consumer (infusal.io): production build injects all three GSAP globals **case-correct**; the live page runs every GSAP/ScrollTrigger animation with zero console errors.

Depends on mod-utils v6.8.0 (already released). Coordinated with mod-gsap / mod-bootstrap / mod-flexsearch declaration PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)