### PR TITLE
fix(deps): patch audited advisories and gate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,31 @@ on:
       - beta
 
 jobs:
+  audit:
+    name: Audit dependencies for known vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: "**/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Audit dependencies for known vulnerabilities
+        run: pnpm audit --prod --audit-level=high
+
   release:
+    needs: audit
     uses: gethinode/.github/.github/workflows/release.yml@v1
     with:
       package-manager: pnpm

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  adm-zip: '>=0.6.0'
+  svgo: '>=4.0.2'
+  tar: '>=7.5.19'
+
 importers:
 
   .:
@@ -533,9 +538,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@9.0.0:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
@@ -2984,8 +2989,8 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
-  svgo@4.0.1:
-    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
+  svgo@4.0.2:
+    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -2997,8 +3002,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   temp-dir@3.0.0:
@@ -3771,7 +3776,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   agent-base@9.0.0: {}
 
@@ -4853,8 +4858,8 @@ snapshots:
 
   hugo-extended@0.164.0:
     dependencies:
-      adm-zip: 0.5.17
-      tar: 7.5.16
+      adm-zip: 0.6.0
+      tar: 7.5.21
 
   human-signals@5.0.0: {}
 
@@ -5894,7 +5899,7 @@ snapshots:
     dependencies:
       postcss: 8.5.21
       postcss-value-parser: 4.2.0
-      svgo: 4.0.1
+      svgo: 4.0.2
 
   postcss-unique-selectors@8.0.1(postcss@8.5.21):
     dependencies:
@@ -6452,7 +6457,7 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  svgo@4.0.1:
+  svgo@4.0.2:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
@@ -6472,7 +6477,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tar@7.5.16:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,15 @@ allowBuilds:
   # add more only when a postinstall failure is investigated and trusted
 minimumReleaseAgeExclude:
   - "@gethinode/*"
+
+# Force-patch transitive deps flagged by `pnpm audit --prod --audit-level=high`.
+# adm-zip: hugo-extended pins ^0.5.17 (crafted-ZIP ~4GB alloc DoS,
+#   GHSA-xcpc-8h2w-3j85 / CVE-2026-39244); force the patched 0.6.x.
+# tar: hugo-extended's tar 7.5.16 carries node-tar DoS advisories; force >=7.5.19.
+# svgo: cssnano > postcss-svgo pulls svgo 4.0.1 (removeScripts high advisory);
+#   force the patched >=4.0.2.
+# Drop each override once the upstream range ships the patched version.
+overrides:
+  adm-zip: ">=0.6.0"
+  svgo: ">=4.0.2"
+  tar: ">=7.5.19"


### PR DESCRIPTION
`pnpm audit --prod` reports **6 advisories** in production transitive dependencies — all shipping today because the project carries no dependency overrides and the release workflow never audits:

| Package | Severity | Via | Resolved | Patched |
|---|---|---|---|---|
| `tar@7.5.16` | **critical** + high + 2 moderate | hugo-extended | 7.5.16 | ≥7.5.19 (node-tar DoS set) |
| `adm-zip@0.5.17` | high | hugo-extended | 0.5.17 | ≥0.6.0 (GHSA-xcpc-8h2w-3j85 / CVE-2026-39244) |
| `svgo@4.0.1` | high | cssnano → postcss-svgo | 4.0.1 | ≥4.0.2 (removeScripts) |

## Changes

**1. `pnpm-workspace.yaml` overrides** — force the patched versions (hugo-extended pins `adm-zip ^0.5.17`, so a plain refresh can't reach them):

```yaml
overrides:
  adm-zip: ">=0.6.0"
  svgo: ">=4.0.2"
  tar: ">=7.5.19"
```

**2. `release.yml` audit gate** — a `pnpm audit --prod --audit-level=high` job that the release job `needs`, so a HIGH+ prod advisory fails the release instead of shipping silently. Release delegates to the org-wide `gethinode/.github` reusable workflow, so the gate lives locally here to avoid changing every `gethinode/*` module's release at once (that reusable workflow would be the alternative home if org-wide gating is preferred).

## Verification

Fresh install with the overrides resolves `adm-zip@0.6.0`, `svgo@4.0.2`, `tar@7.5.21`; `pnpm audit --prod --audit-level=high` → **No known vulnerabilities found** (was: 1 critical, 3 high, 2 moderate). Lockfile diff is scoped to the security set + their subtrees. Drop each override once the upstream range ships the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)