### PR TITLE
fix(ci): move audit to its own workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,35 @@
+name: Audit
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+      - beta
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit dependencies for known vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "lts/*"
+          cache: pnpm
+          cache-dependency-path: "**/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Audit dependencies for known vulnerabilities
+        run: pnpm audit --prod --audit-level=high

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,18 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
+      - name: Set up Hinode toolchain
+        uses: gethinode/.github/actions/setup-hinode@v1
         with:
-          node-version: "lts/*"
-          cache: pnpm
-          cache-dependency-path: "**/pnpm-lock.yaml"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+          package-manager: pnpm
 
       - name: Audit dependencies for known vulnerabilities
         run: pnpm audit --prod --audit-level=high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,31 +7,7 @@ on:
       - beta
 
 jobs:
-  audit:
-    name: Audit dependencies for known vulnerabilities
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: lts/*
-          cache: pnpm
-          cache-dependency-path: "**/pnpm-lock.yaml"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Audit dependencies for known vulnerabilities
-        run: pnpm audit --prod --audit-level=high
-
   release:
-    needs: audit
     uses: gethinode/.github/.github/workflows/release.yml@v1
     with:
       package-manager: pnpm


### PR DESCRIPTION
Follow-up to #2074. The audit job I added to `release.yml` gated the reusable-workflow call (`gethinode/.github/release.yml@v1`) via `needs: audit`. GitHub rejects a `needs`-gated reusable-workflow caller sitting alongside a sibling `steps` job with `secrets: inherit` — the Release run fails at **startup** ("This run likely failed because of a workflow file issue"), so `main` could not release. (`actionlint` does not model this constraint, so it passed locally.)

## Fix

- **`release.yml`** — restored to the original single reusable-workflow job (identical to the long-green version).
- **`audit.yml`** — new standalone workflow running `pnpm audit --prod --audit-level=high` on `push` (main, beta) and `pull_request`.

The dependency overrides from #2074 (adm-zip/tar/svgo) are unaffected and remain in place — audit is clean.

### Note on gating
This runs the audit as its own required-check-able workflow rather than a hard `needs` gate on the release job. To block merges on it, add **Audit** to the branch's required status checks. If a hard gate on the release job itself is preferred, the clean way is an opt-in `audit` input/step in the shared `gethinode/.github` release workflow — happy to follow up with that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)