### PR TITLE
feat: add an optional action slot to section-title

### DIFF
--- a/data/structures/section-title.yml
+++ b/data/structures/section-title.yml
@@ -18,3 +18,5 @@ arguments:
   arrangement:
   heading-style:
   content-style:
+  action:
+    optional: true

--- a/layouts/_partials/assets/section-title.html
+++ b/layouts/_partials/assets/section-title.html
@@ -78,6 +78,16 @@
     ) }}
 {{ end }}
 
+{{/* Optional action slot: pre-rendered HTML (typically a button) placed on the
+     title's own row, pushed to the trailing edge. A section landing page's
+     primary action belongs beside its title rather than buried in the body, and
+     the heading is rendered here, so this is the only place that can put it
+     there. Wrapping happens only when both a header and an action exist, so the
+     markup is byte-identical to before for every existing caller. */}}
+{{ if and $header $args.action }}
+    {{ $header = printf `<div class="d-flex align-items-center gap-3 section-title-row">%s<div class="section-title-action ms-auto flex-shrink-0">%s</div></div>` $header $args.action | safeHTML }}
+{{ end }}
+
 {{ $links := "" }}
 {{ if $args.links }}
     {{ $links = partial "assets/links.html" (dict

--- a/layouts/_partials/page/articles.html
+++ b/layouts/_partials/page/articles.html
@@ -1,6 +1,18 @@
 {{/* Add default hero and articles for list pages */}}
 {{- $padding := partial "utilities/GetPadding.html" -}}
 
+{{/* Read the caller's params before rendering the header: the header now
+     accepts an optional action, so it can no longer be emitted before the
+     params that may carry one have been read. */}}
+{{ $articlesParams := $.Scratch.Get "articlesParams" }}
+{{/* Cast to string: callers pass rendered markup, which arrives as template.HTML,
+     and the argument validator type-checks against string. section-title marks it
+     safe again when it composes the header row. */}}
+{{ $sectionAction := "" }}
+{{ if reflect.IsMap $articlesParams }}
+    {{ with index $articlesParams "action" }}{{ $sectionAction = printf "%s" . }}{{ end }}
+{{ end }}
+
 {{/* Render basic header for list page */}}
 {{ if .Site.Params.navigation.breadcrumb }}
     {{ partial "assets/breadcrumb.html" (dict "page" .) }}
@@ -13,10 +25,10 @@
         "align"   "start"
     )
     "use-title" true
+    "action"    $sectionAction
 ) }}
 
 {{/* Init the card styling */}}
-{{ $articlesParams := $.Scratch.Get "articlesParams" }}
 {{ $sort := "date" }}
 {{ $reverse := true }}
 {{ $class := "border-0 h-100" }}


### PR DESCRIPTION
## Problem

A section landing page's primary action has nowhere to go. `assets/section-title` owns the heading markup, so a caller wanting a button beside the title can only render it into the body below — where it competes with the section's own content and shifts position depending on what else the page shows.

## Change

`assets/section-title` gains an optional `action` argument: pre-rendered markup placed on the title's own row and pushed to the trailing edge. `page/articles` forwards it from `articlesParams`, so list pages can supply one.

Reading `articlesParams` moves above the header render — the header can no longer be emitted before the params that may carry an action have been read.

```go-html-template
{{ $.Scratch.Set "articlesParams" (dict
    "sort"   "weight"
    "action" (partial "ui/page-action" (dict "page" .))
) }}
{{ partial "page/articles.html" . }}
```

## Backward compatibility

Structural, not just tested: the wrapper is emitted **only when a header and an action are both present**, so markup is byte-identical for every existing caller.

Verified against this site's own build — every page using `section-title` renders exactly as before, and none gains the new wrapper.

## Notes

- `action` is declared in `data/structures/section-title.yml`; the arg validator type-checks against `string`, so callers pass rendered markup and `section-title` marks it safe when composing the row.
- The row uses `align-items-center`. Bottom alignment placed the button in the descender gap below the baseline, and degrades worse when a title wraps to two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)