### PR TITLE
fix(sidebar): share the collapse timing through a variable

### DIFF
--- a/assets/scss/common/_variables-dart.scss
+++ b/assets/scss/common/_variables-dart.scss
@@ -55,6 +55,15 @@ $primary-border-subtle-dark:        mix(black, h.$primary, calc(h.$dark-mode-sha
 // Shared by every element that repaints on a color mode switch, so they stay in sync.
 $theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out, border-color .5s ease-in-out !default;
 
+// Timing of the sidebar collapse/expand gesture. Several properties animate at
+// once and on more than one element — the label's max-width and inline-start
+// margin here, the column's width in a downstream theme — so they share a
+// duration and easing rather than each carrying its own literal. Exposed as a
+// duration/easing pair, not a `transition` shorthand, because the property
+// lists differ per element. Changing either value retimes the whole gesture.
+$sidebar-collapse-transition-duration: 0.2s !default;
+$sidebar-collapse-transition-easing: ease !default;
+
 $dropdown-transition: opacity .15s ease-in-out !default;
 $dropdown-horizontal-margin-top: calc((-1.5 * 1rem) - 2px);
 $dropdown-horizontal-padding-y: calc(1rem + 2px);

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -50,6 +50,17 @@ $primary-border-subtle-dark:        mix(black, $primary, $dark-mode-shade / 2) !
 $theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out, border-color .5s ease-in-out !default;
 // scss-docs-end color-mode-transition
 
+// scss-docs-start sidebar-collapse-transition
+// Timing of the sidebar collapse/expand gesture. Several properties animate at
+// once and on more than one element — the label's max-width and inline-start
+// margin here, the column's width in a downstream theme — so they share a
+// duration and easing rather than each carrying its own literal. Exposed as a
+// duration/easing pair, not a `transition` shorthand, because the property
+// lists differ per element. Changing either value retimes the whole gesture.
+$sidebar-collapse-transition-duration: 0.2s !default;
+$sidebar-collapse-transition-easing: ease !default;
+// scss-docs-end sidebar-collapse-transition
+
 // scss-docs-start horizontal-nav
 $dropdown-transition: opacity .15s ease-in-out !default;
 $dropdown-horizontal-margin-top: calc((-1.5 * 1rem) - 2px);

--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -1,3 +1,10 @@
+// Self-sufficient defaults — see common/_styles.scss for the rationale
+// (child themes shadowing common/_variables.scss). Downstream themes that
+// animate their own part of the collapse gesture reference these, so the
+// column and the labels inside it retime together instead of drifting apart.
+$sidebar-collapse-transition-duration: 0.2s !default;
+$sidebar-collapse-transition-easing: ease !default;
+
 // scss-docs-start sidebar
 .sidebar {
     top: var(--navbar-offset);
@@ -236,7 +243,13 @@ html.sidebar-pre-collapsed .sidebar-collapsible .sidebar-item-label {
     overflow: hidden;
     white-space: nowrap;
     vertical-align: middle;
-    transition: max-width 0.2s ease, opacity 0.15s ease, margin-inline-start 0.2s ease;
+
+    // Geometry rides the shared collapse timing; the fade is deliberately
+    // shorter so the label is gone before the track finishes narrowing.
+    transition:
+        max-width $sidebar-collapse-transition-duration $sidebar-collapse-transition-easing,
+        opacity 0.15s ease,
+        margin-inline-start $sidebar-collapse-transition-duration $sidebar-collapse-transition-easing;
 }
 
 .sidebar-collapsed {


### PR DESCRIPTION
## Problem

The sidebar collapse gesture animates more than one element. Hinode narrows and fades `.sidebar-item-label`; a downstream theme animates the width of the column those labels sit in. Both run at 200ms — but that relationship was held by **two unrelated literals in two repositories**, with nothing enforcing it.

Retime one and the labels finish while the track is still moving, silently and with no failing test.

## Change

Extract the duration and the easing so the gesture has one definition:

```scss
$sidebar-collapse-transition-duration: 0.2s !default;
$sidebar-collapse-transition-easing: ease !default;
```

**Two variables rather than one `transition` shorthand**, because the property lists genuinely differ — the label animates `max-width` and `margin-inline-start`, the column animates `width`. The easing is shared as well as the duration: equal durations with different easing still drift apart mid-flight, so exporting only half the invariant would not close the gap.

`opacity` keeps its own `0.15s`. That fade is meant to lead the geometry and is deliberately not part of the invariant.

Declared `!default` in `common/_variables.scss` (with `scss-docs` markers) and `common/_variables-dart.scss`, plus a self-sufficient default at the top of `components/_sidebar.scss` — the idiom `$theme-mode-transition` already uses.

**The last of those is the load-bearing one in practice.** Child themes commonly fork the variables files, which silently drops variables added upstream; the declaration next to the usage is what survives that. Verified on a real downstream: a sentinel left only in `common/_variables-dart.scss` had no effect, because the consuming theme forks that file.

Because every declaration is `!default`, a downstream theme can carry its own copy today and pick this one up automatically once released — no flag day, no coordinated release.

## Not touched

- `0.35s` (line 130) and `0.4s` (line 229) transforms — different gestures.
- The secondary group's `0.2s` chevron (line 315). That belongs to the `.sidebar-secondary-toggle` disclosure — a Bootstrap collapse with its own script and storage key. It shares the number, not the concept. The sidebar's own collapse chevron is the 0.4s at line 229, which settles it.

## Nothing is retimed — verified

The **entire** compiled stylesheet is byte-identical before and after, on a real downstream build:

```
44b48aa3b372b7d4db42621dfaf2a5e21e2a897a08e8dfb0841e1841ffec0db8   before
44b48aa3b372b7d4db42621dfaf2a5e21e2a897a08e8dfb0841e1841ffec0db8   after
```

184,365 lines, `cmp` clean — including the three rules that matter:

```css
.sidebar-item-label { transition: max-width 0.2s ease, opacity 0.15s ease, margin-inline-start 0.2s ease; }
.app-shell-sidebar  { transition: width 0.2s ease; }
[data-bs-theme-animate=true] .app-shell-sidebar {
  transition: background-color 0.5s ease-in-out, color 0.5s ease-in-out, border-color 0.5s ease-in-out, width 0.2s ease;
}
```

And the property the change exists to create: setting the defaults here to a sentinel `0.77s` / `linear` moves the label **and** the downstream column together —

```css
.sidebar-item-label { transition: max-width 0.77s linear, opacity 0.15s ease, margin-inline-start 0.77s linear; }
[data-bs-theme-animate=true] .app-shell-sidebar { … width 0.77s linear; }
.sidebar-secondary-icon { transition: transform 0.2s ease; }   /* correctly unaffected */
```

`pnpm lint` and `pnpm test` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)