### PR TITLE
fix(sidebar): hold the collapsed-mode centring until the collapse settles

### DIFF
--- a/assets/scss/common/_variables-dart.scss
+++ b/assets/scss/common/_variables-dart.scss
@@ -64,6 +64,17 @@ $theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out,
 $sidebar-collapse-transition-duration: 0.2s !default;
 $sidebar-collapse-transition-easing: ease !default;
 
+// Sequencing for the collapsed-mode centring refinements on a sidebar item. These
+// are discrete properties, so they land on the tick the collapsed class flips —
+// before the column and the labels have finished collapsing. A zero-duration
+// transition defers the change without animating it; the `-delayed` variant holds
+// it until the collapse geometry has settled. Exposed because `transition` is a
+// shorthand: a downstream theme declaring its own on `.sidebar-item` replaces
+// these slots rather than extending them, and has to restate them. Only valid
+// inside `@supports (transition-behavior: allow-discrete)`.
+$sidebar-collapse-refinement-transition: text-align 0s allow-discrete, justify-content 0s allow-discrete !default;
+$sidebar-collapse-refinement-transition-delayed: text-align 0s $sidebar-collapse-transition-duration allow-discrete, justify-content 0s $sidebar-collapse-transition-duration allow-discrete !default;
+
 $dropdown-transition: opacity .15s ease-in-out !default;
 $dropdown-horizontal-margin-top: calc((-1.5 * 1rem) - 2px);
 $dropdown-horizontal-padding-y: calc(1rem + 2px);

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -61,6 +61,19 @@ $sidebar-collapse-transition-duration: 0.2s !default;
 $sidebar-collapse-transition-easing: ease !default;
 // scss-docs-end sidebar-collapse-transition
 
+// scss-docs-start sidebar-collapse-refinement-transition
+// Sequencing for the collapsed-mode centring refinements on a sidebar item. These
+// are discrete properties, so they land on the tick the collapsed class flips —
+// before the column and the labels have finished collapsing. A zero-duration
+// transition defers the change without animating it; the `-delayed` variant holds
+// it until the collapse geometry has settled. Exposed because `transition` is a
+// shorthand: a downstream theme declaring its own on `.sidebar-item` replaces
+// these slots rather than extending them, and has to restate them. Only valid
+// inside `@supports (transition-behavior: allow-discrete)`.
+$sidebar-collapse-refinement-transition: text-align 0s allow-discrete, justify-content 0s allow-discrete !default;
+$sidebar-collapse-refinement-transition-delayed: text-align 0s $sidebar-collapse-transition-duration allow-discrete, justify-content 0s $sidebar-collapse-transition-duration allow-discrete !default;
+// scss-docs-end sidebar-collapse-refinement-transition
+
 // scss-docs-start horizontal-nav
 $dropdown-transition: opacity .15s ease-in-out !default;
 $dropdown-horizontal-margin-top: calc((-1.5 * 1rem) - 2px);

--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -4,6 +4,8 @@
 // column and the labels inside it retime together instead of drifting apart.
 $sidebar-collapse-transition-duration: 0.2s !default;
 $sidebar-collapse-transition-easing: ease !default;
+$sidebar-collapse-refinement-transition: text-align 0s allow-discrete, justify-content 0s allow-discrete !default;
+$sidebar-collapse-refinement-transition-delayed: text-align 0s $sidebar-collapse-transition-duration allow-discrete, justify-content 0s $sidebar-collapse-transition-duration allow-discrete !default;
 
 // scss-docs-start sidebar
 .sidebar {
@@ -301,6 +303,66 @@ html.sidebar-pre-collapsed .sidebar-collapsible {
 
     .sidebar-item .me-1 {
         margin-right: 0 !important;
+    }
+}
+
+// Sequence the centring refinements above behind the geometry they belong to.
+//
+// They are position changes, not animations: `text-align` and `justify-content`
+// are discrete, and the paddings flip in one step. So they all land on the tick
+// the collapsed class flips, while the labels (and, in a downstream theme, the
+// column width) are still mid-collapse. Centring an icon+label pair inside a
+// still-full-width column throws the icon far to the right for one frame — ~50px
+// in a 16rem column — after which it sweeps back past its resting place as the
+// column narrows, because the icon sits at `(columnWidth - contentWidth) / 2` and
+// those two shrink on different curves. Three direction changes for a gesture
+// that should read as one motion.
+//
+// A zero-duration transition with a delay defers a value change without animating
+// it, and `transition-behavior: allow-discrete` lets the keyword properties take
+// part at all. The delay is the shared collapse duration, so the refinements land
+// exactly as the labels and the column finish: the icon holds still throughout and
+// steps once into its centred position. The gesture is not lengthened.
+//
+// Only the collapsed state carries the delay. A transition takes its timing from
+// the after-change style, so collapsing defers and expanding does not — which is
+// what expand needs: the refinements have to be gone before the column widens, or
+// the now icon-only rows would re-centre in an ever-wider track and sweep right.
+//
+// `white-space` and `overflow` are deliberately excluded and still land at once;
+// they are what stops the collapsing label wrapping to a second line.
+//
+// Progressive enhancement: without `transition-behavior` the refinements land
+// immediately, exactly as they did before this block existed.
+@supports (transition-behavior: allow-discrete) {
+    .sidebar-collapsible {
+        &.sidebar {
+            transition: padding-left 0s;
+        }
+
+        .sidebar-toggle-container {
+            transition: justify-content 0s allow-discrete, padding-right 0s;
+        }
+
+        .sidebar-item {
+            transition: $sidebar-collapse-refinement-transition;
+        }
+
+        .sidebar-item .me-1 {
+            transition: margin-right 0s;
+        }
+    }
+
+    .sidebar-collapsed {
+        &.sidebar,
+        .sidebar-toggle-container,
+        .sidebar-item .me-1 {
+            transition-delay: $sidebar-collapse-transition-duration;
+        }
+
+        .sidebar-item {
+            transition: $sidebar-collapse-refinement-transition-delayed;
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Collapsing the sidebar makes the icon jump right, then sweep back past where it lands. Three direction changes for a gesture that should read as one motion.

The collapsed-mode refinements are position changes, not animations — `text-align` and `justify-content` are discrete, and the paddings flip in one step. So they all land on the tick `.sidebar-collapsed` is added, while the labels (and, in a downstream theme, the column width) are still mid-collapse.

Centring an icon+label pair inside a still-full-width column throws the icon far to the right for one frame — **~50px in a 16rem column** — after which it sweeps back past its resting place as the column narrows, because the icon sits at `(columnWidth − contentWidth) / 2` and those two shrink on different curves.

Traced per `requestAnimationFrame`, first item, 1440×900:

| moment | column width | icon `x` |
| --- | --- | --- |
| before click | 256.00 | 20.00 |
| **same tick** | 256.00 | **70.67** ← +50.67px, instantly |
| t≈61ms | 178.06 | 32.50 |
| t≈73ms | 142.52 | 19.81 ← past its resting place |
| settled | 60.00 | 21.50 |

## Fix

A zero-duration transition with a delay defers a value change without animating it, and `transition-behavior: allow-discrete` lets the keyword properties take part at all. The delay is the shared `$sidebar-collapse-transition-duration`, so the refinements land exactly as the labels and the column finish — the icon holds still throughout and steps once into its centred position.

**The gesture is not lengthened**, and duration, easing, start state and end state are all unchanged.

Only the collapsed state carries the delay. A transition takes its timing from the after-change style, so collapsing defers and expanding does not — which is what expand needs: the refinements have to be gone *before* the column widens, or the now icon-only rows would re-centre in an ever-wider track and sweep right.

`white-space` and `overflow` are deliberately excluded and still land at once — they are what stops the collapsing label wrapping to a second line.

### Note on the obvious alternative

"Hide the labels first, then animate the width" does **not** work, and is worse than the current behaviour. Delaying `width` leaves `text-align: center` landing on the click tick regardless, centring a full-width label in a full-width column. And once the labels are gone with the column still at 256px, the icon sits at ~120px and then sweeps to 22 — a *larger* excursion than the ~50px it makes today, plus a doubled gesture time. Deferring the centring is what removes the motion; delaying the geometry is not.

## Results

| | before | after |
| --- | --- | --- |
| instant jump on click tick | **50.67px** | **0.00px** |
| overshoot past resting | 1.70px | **0** (min = start) |
| direction changes | **3** | **1** |
| settle | 213.4ms | 219.5ms (one frame later) |
| row height | 30.77 throughout | 30.77 throughout |

Other elements in the same collapse, instant jump before → after: chevron **−102.75 → 0**, brand **−4 → 0**, footer link **−4 → 0**.

**Interrupt-safe.** Re-clicking mid-gesture (~96ms): before, 3 direction changes and the icon centred while the column was still wide; after, the icon never moves at all and the column ends correctly at 256px with `text-align: start`.

**Expand unchanged** by design — 1 direction change, 0 overshoot, before and after. **Pre-collapsed first paint** identical, no flash.

## Progressive enhancement

Everything is inside `@supports (transition-behavior: allow-discrete)`. Without support the refinements land immediately — **exactly as they did before this block existed**. That failure mode is why this is CSS rather than a `transitionend` chain: a JS chain that never fires leaves the refinements permanently unapplied and the collapsed sidebar left-aligned, which is worse than the bug it fixes. `allow-discrete` and `@starting-style` already ship in `components/_lightbox.scss`, so the baseline is established.

Additive only — **+86/−0**, no existing declaration modified. `pnpm lint` and `pnpm test` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)