### PR TITLE
fix(sidebar): stop labels wrapping while the sidebar expands

### DIFF
--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -6,6 +6,8 @@ $sidebar-collapse-transition-duration: 0.2s !default;
 $sidebar-collapse-transition-easing: ease !default;
 $sidebar-collapse-refinement-transition: text-align 0s allow-discrete, justify-content 0s allow-discrete !default;
 $sidebar-collapse-refinement-transition-delayed: text-align 0s $sidebar-collapse-transition-duration allow-discrete, justify-content 0s $sidebar-collapse-transition-duration allow-discrete !default;
+$sidebar-collapse-clipping-transition: white-space 0s allow-discrete, overflow 0s allow-discrete !default;
+$sidebar-collapse-clipping-transition-delayed: white-space 0s $sidebar-collapse-transition-duration allow-discrete, overflow 0s $sidebar-collapse-transition-duration allow-discrete !default;
 
 // scss-docs-start sidebar
 .sidebar {
@@ -329,11 +331,26 @@ html.sidebar-pre-collapsed .sidebar-collapsible {
 // what expand needs: the refinements have to be gone before the column widens, or
 // the now icon-only rows would re-centre in an ever-wider track and sweep right.
 //
-// `white-space` and `overflow` are deliberately excluded and still land at once;
-// they are what stops the collapsing label wrapping to a second line.
+// `white-space` and `overflow` carry the mirror image of that delay, because the
+// direction that needs them held is the opposite one. They are the clipping pair:
+// `nowrap` keeps the (max-width: 0) label on the icon's line and `hidden` stops it
+// spilling out of a column narrower than its text.
 //
-// Progressive enhancement: without `transition-behavior` the refinements land
-// immediately, exactly as they did before this block existed.
+// Collapsing, they must land at once — the label is still full width on the tick
+// the class flips, so anything later lets it wrap. Expanding, landing at once is
+// exactly the bug: `nowrap` is *removed* on that tick while the column is still
+// widening, so for a few frames the label sits in a track too narrow to hold it,
+// wraps to a second line, and doubles every row's height until the width catches
+// up. Measured at 1440x900: rows peak at 54.77px against a settled 30.77px, with
+// the column only 140px wide and the label already 82px.
+//
+// So the delay goes on the expanded state, not the collapsed one — the inverse of
+// the centring refinements above. Same mechanism, opposite assignment: the
+// after-change style supplies the timing, so the clipping pair defers on expand
+// and lands immediately on collapse, and both directions hold their row height.
+//
+// Progressive enhancement: without `transition-behavior` every property here lands
+// immediately, exactly as it did before this block existed.
 @supports (transition-behavior: allow-discrete) {
     .sidebar-collapsible {
         &.sidebar {
@@ -345,7 +362,7 @@ html.sidebar-pre-collapsed .sidebar-collapsible {
         }
 
         .sidebar-item {
-            transition: $sidebar-collapse-refinement-transition;
+            transition: $sidebar-collapse-refinement-transition, $sidebar-collapse-clipping-transition-delayed;
         }
 
         .sidebar-item .me-1 {
@@ -361,7 +378,7 @@ html.sidebar-pre-collapsed .sidebar-collapsible {
         }
 
         .sidebar-item {
-            transition: $sidebar-collapse-refinement-transition-delayed;
+            transition: $sidebar-collapse-refinement-transition-delayed, $sidebar-collapse-clipping-transition;
         }
     }
 }


### PR DESCRIPTION
## Problem

Expanding the sidebar makes every item row grow to double height for a few frames, then snap back.

`white-space: nowrap` lives in the `.sidebar-collapsed` block. It is discrete, so it vanishes on the tick the class comes off — while `width` is still animating open. For that window the label sits in a track too narrow to hold it and wraps to a second line. `overflow: hidden` pairs with it.

Traced per `requestAnimationFrame`, first `.sidebar-item`, 1440×900:

| | value |
| --- | --- |
| collapsed row height, pre-expand | **30.77px**, `white-space: nowrap` |
| **peak during expand** | **54.77px** (+24.00px) |
| final | **30.77px** |

At the peak the column is only **139px** wide while the label is already **82px** — wider than the space beside the icon.

## Fix — the mirror of the collapse deferral

The `@supports (transition-behavior: allow-discrete)` block already added for the collapse gesture holds the *centring* refinements back until the width settles. This adds the clipping pair on the **opposite** assignment:

```scss
$sidebar-collapse-clipping-transition:         white-space 0s allow-discrete, overflow 0s allow-discrete !default;
$sidebar-collapse-clipping-transition-delayed: white-space 0s $sidebar-collapse-transition-duration allow-discrete, …
```

`.sidebar-collapsible .sidebar-item` takes the **delayed** pair; `.sidebar-collapsed .sidebar-item` takes the **immediate** pair — the inverse of how the refinement variables are assigned.

That asymmetry is the whole point. A transition takes its timing from the **after-change** style, and the two directions need opposite treatment:

- **Collapsing**, the clipping pair must land at once — the label is still full width on the tick the class flips, so anything later lets it wrap.
- **Expanding**, landing at once *is* the bug — `nowrap` is removed while the column is still widening.

The previous comment said these were "deliberately excluded"; that was correct for collapse only, and is replaced rather than left to mislead.

Two new `!default` variables so downstream themes can retime. Nothing outside the existing `@supports` gate, so a browser without `transition-behavior` sees exactly today's behaviour.

## Results — rAF traces

**Expand**

| | before | after |
| --- | --- | --- |
| settled row height | 30.77px | 30.77px |
| **peak** | **54.77px** | **30.77px** (peak = start) |
| excursion | **+24.00px** | **0px** |
| `white-space` → `normal` | t=76.8ms, aside still **60px** | t=284.8ms, aside **256px** (fully open) |

Like-for-like frame: before, at aside=139.94px the row was 54.77px; after, at aside=142.48px it is 30.77px. Every sampled frame after the fix reads 30.77px.

**Collapse — unchanged**

| | before | after |
| --- | --- | --- |
| row height, all frames | 30.77px | 30.77px |
| `white-space` → `nowrap` | click tick, aside 256px | click tick, aside 256px |
| `text-align` → `center` | t=233ms (deferred) | t=232.8ms (deferred) |

The existing collapse-sequencing guarantees hold: icon travels 20 → 21.5px with **no instant jump on the click tick**, **no overshoot** (min = start, max = end), and **one direction of travel**.

**Pre-collapsed first paint** (`localStorage sidebar-collapsed=1`), 98 frames: distinct row heights `[30.77]`, widths `[60]`, `white-space` `["nowrap"]` — single value each, no flash.

`pnpm lint` and `pnpm test` exit 0.

## Note

`overflow` is a shorthand. Confirmed empirically that Chrome accepts it in a `transition-property` list and defers it (flip at 284.8ms on expand, at the click tick on collapse). Worth knowing if this ever needs splitting to `overflow-x`/`overflow-y` for a browser that disagrees.

The gesture duration is unchanged at 0.2s in both directions — this defers within it and does not lengthen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)