### PR TITLE
fix(sidebar): crossfade the brand marks instead of cutting between them

### DIFF
--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -30,8 +30,13 @@ $sidebar-collapse-clipping-transition-delayed: white-space 0s $sidebar-collapse-
         height: auto;
     }
 
+    .sidebar-brand-full {
+        opacity: 1;
+    }
+
     .sidebar-brand-mark {
         display: none;
+        opacity: 0;
     }
 }
 
@@ -43,10 +48,12 @@ html.sidebar-pre-collapsed .sidebar-collapsible .sidebar-brand {
 
     .sidebar-brand-full {
         display: none;
+        opacity: 0;
     }
 
     .sidebar-brand-mark {
         display: inline-block;
+        opacity: 1;
     }
 }
 
@@ -380,6 +387,73 @@ html.sidebar-pre-collapsed .sidebar-collapsible {
         .sidebar-item {
             transition: $sidebar-collapse-refinement-transition-delayed, $sidebar-collapse-clipping-transition;
         }
+    }
+}
+
+// Crossfade the two brand marks rather than cutting between them.
+//
+// The brand swap is a `display` change, so it is discrete by nature: the full
+// logo vanishes and the mark appears on the same tick the collapsed class
+// flips, while the column is still 16rem and narrowing. Deferring the swap to
+// the end of the gesture does not fix that — a later hard cut is still a hard
+// cut. Overlapping the two with opacity is what makes it read as one motion.
+//
+// Three pieces are needed:
+//
+//   * The brand becomes a single-cell grid so both marks share one origin.
+//     While both are rendered a flex row would place them side by side and the
+//     brand would visibly double in width mid-gesture.
+//   * `display` joins the transition with `transition-behavior: allow-discrete`,
+//     which keeps the outgoing mark rendered for the whole fade instead of
+//     dropping it on the tick, and `@starting-style` gives the incoming mark a
+//     value to fade up from.
+//   * The brand's own centring is deferred behind the collapse, exactly as the
+//     item rows' is above. Without it `justify-content: center` lands on the
+//     click tick and the fade happens at the centre of a column that is still
+//     full width — the mark appears ~100px to the right of the logo it is
+//     replacing and then slides back as the column narrows. Deferred, the two
+//     marks sit at the same x for the whole fade.
+//
+// Rest states are unchanged: exactly one mark is rendered at rest, so the grid
+// track is sized by it alone and the layout matches the `display` swap this
+// replaces. Both directions are covered — a transition takes its timing from
+// the after-change style, and the fade is symmetric, so only the deferral of
+// the centring is one-directional (collapse defers, expand does not, for the
+// same reason the item rows' does).
+//
+// Progressive enhancement: without `transition-behavior` the whole block is
+// skipped, the brand stays a flex row and the marks cut over exactly as before.
+@supports (transition-behavior: allow-discrete) {
+    .sidebar-collapsible .sidebar-brand {
+        display: grid;
+        transition: justify-content 0s allow-discrete, padding-left 0s, padding-right 0s;
+
+        // Stack every child in the one cell. The brand renders each mark
+        // through `assets/image.html`, which wraps it when light and dark
+        // variants are supplied — so match the children, not the marks.
+        > * {
+            grid-area: 1 / 1;
+        }
+
+        // `@starting-style` competes on specificity like any other rule, so the
+        // starting value has to be declared at least as specifically as the
+        // `opacity: 1` it fades up from. Scoped one class shorter, this loses to
+        // the collapsed-state rule and the incoming mark appears at full opacity
+        // on collapse while only the outgoing one fades.
+        .sidebar-brand-full,
+        .sidebar-brand-mark {
+            transition:
+                opacity $sidebar-collapse-transition-duration $sidebar-collapse-transition-easing,
+                display $sidebar-collapse-transition-duration allow-discrete;
+
+            @starting-style {
+                opacity: 0;
+            }
+        }
+    }
+
+    .sidebar-collapsed .sidebar-brand {
+        transition-delay: $sidebar-collapse-transition-duration;
     }
 }
 


### PR DESCRIPTION
## Problem

Collapsing the sidebar swaps `.sidebar-brand-full` for `.sidebar-brand-mark` with `display`. That is discrete by nature, so it cuts on the click tick while the column is still animating — one mark blinks out and another blinks in, 200ms before the motion around them finishes.

## Fix

`.sidebar-brand` becomes a single-cell grid so both marks share one origin (a flex row would sit them side by side while both are rendered). `display` joins the transition with `transition-behavior: allow-discrete` so the outgoing mark stays rendered through the fade, and `@starting-style` gives the incoming one a value to fade up from.

Timing comes from `$sidebar-collapse-transition-duration` / `-easing` — **no new literal**, so one upstream change still retimes the whole gesture. Everything sits inside `@supports (transition-behavior: allow-discrete)`; an unsupporting browser keeps today's flex row and today's cut.

## Results — rAF traces, 1440×900

| | before | after |
| --- | --- | --- |
| collapse — distinct full-logo opacities | **1** | **25** |
| collapse — distinct mark opacities | **1** | **25** |
| collapse — frames with **both** painted | **0** | **22** |
| expand — full / mark distinct | 1 / 1 | **25 / 25** |
| expand — frames with both painted | **0** | **22** |

## The crossfade alone was not enough — and measuring found a bigger defect

With only the opacity work, the whole brand **jumped x=20 → 87 on the click tick** and slid back: the fade was happening 67px from the logo it replaced. `.sidebar-brand`'s own `justify-content`/padding were still landing immediately.

Deferring those behind the collapse — the identical treatment `.sidebar-toggle-container` already has — fixed that, and also fixed a **previously unmeasured 99.5px jump in the baseline**: collapsing, the mark used to appear at x=119.5 and travel 100px back to 19.5, every time.

| brand geometry, collapse | before | after |
| --- | --- | --- |
| jump on click tick | **99.5px** | **0.00px** |
| total travel | 100px | **0.50px** |

The brand's height also stops wobbling on expand (44..48px → 47.92..48).

## Non-regression

Row height constant **30.77px** both directions. Icon: 0.00px jump collapsing, one unchanged 1.50px step expanding, **0 direction changes, 0 overshoot**. Identical again with `data-bs-theme-animate="true"` set, so no downstream `transition` shorthand clobbers the new slots. The expand-wrap fix holds — no row-height excursion.

`@starting-style` does **not** fire on cold page load in either state (`getAnimations()` empty, opacity constant from first paint), because `.sidebar-no-transition` is applied before first styling.

`pnpm lint` and `pnpm test` exit 0.

Refs infusal/app#561 — the footer row's `flex-direction` flip is deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)