### PR TITLE
fix: honour an explicit cue/tab false on links, buttons and link lists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gethinode/mod-lottie/v3 v3.0.4 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.4 // indirect
 	github.com/gethinode/mod-simple-datatables/v4 v4.1.0 // indirect
-	github.com/gethinode/mod-utils/v6 v6.8.3 // indirect
+	github.com/gethinode/mod-utils/v6 v6.8.4 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/gethinode/mod-utils/v6 v6.8.0 h1:Rz/6DlPKVW0791jSsobxx4I4pKQ38H4JOEeO
 github.com/gethinode/mod-utils/v6 v6.8.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/gethinode/mod-utils/v6 v6.8.3 h1:RbQS52Ap9KqqAqNQ7mkFEHw0RbqYBMpJJGPSN5q3jnE=
 github.com/gethinode/mod-utils/v6 v6.8.3/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
+github.com/gethinode/mod-utils/v6 v6.8.4 h1:L8x3IcWEn2kms7WWuYwtbi/x7lIR18z+eJhUjmCek3g=
+github.com/gethinode/mod-utils/v6 v6.8.4/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 h1:QDKcU3q39lFGzdVwM6kgCGnW3ibbMfYIi0Rwl62iJpo=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0/go.mod h1:5GdMfPAXzbA2gXBqTjC6l27kioSYzHlqDMh0+wyx7sU=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=

--- a/layouts/_partials/assets/button.html
+++ b/layouts/_partials/assets/button.html
@@ -50,12 +50,13 @@
 {{- end -}}
 {{- $class := $args.class | default "" }}
 {{ with $args.badge }}{{ $class = printf "%s me-3" $class }}{{ end }}
-{{/* cue carries no schema default, so an absent value is nil and an explicit
-     false is a real choice. "default" treats false as empty and would silently
-     restore the site setting, so test for nil instead. */}}
+{{/* cue and tab carry no schema default, so an absent value is nil and an
+     explicit false is a real choice. "default" treats false as empty and would
+     silently restore the site setting, so test for nil instead. */}}
 {{- $cue := site.Params.main.externalLinks.cue -}}
 {{- if ne $args.cue nil }}{{ $cue = $args.cue }}{{ end -}}
-{{- $tab := $args.tab | default site.Params.main.externalLinks.tab -}}
+{{- $tab := site.Params.main.externalLinks.tab -}}
+{{- if ne $args.tab nil }}{{ $tab = $args.tab }}{{ end -}}
 {{- $externalLink := partial "utilities/GetThemeIcon.html" (dict "id" "externalLink" "default" "fas up-right-from-square") -}}
 
 {{- $isExternal := false }}

--- a/layouts/_partials/assets/button.html
+++ b/layouts/_partials/assets/button.html
@@ -50,7 +50,11 @@
 {{- end -}}
 {{- $class := $args.class | default "" }}
 {{ with $args.badge }}{{ $class = printf "%s me-3" $class }}{{ end }}
-{{- $cue := $args.cue | default site.Params.main.externalLinks.cue -}}
+{{/* cue carries no schema default, so an absent value is nil and an explicit
+     false is a real choice. "default" treats false as empty and would silently
+     restore the site setting, so test for nil instead. */}}
+{{- $cue := site.Params.main.externalLinks.cue -}}
+{{- if ne $args.cue nil }}{{ $cue = $args.cue }}{{ end -}}
 {{- $tab := $args.tab | default site.Params.main.externalLinks.tab -}}
 {{- $externalLink := partial "utilities/GetThemeIcon.html" (dict "id" "externalLink" "default" "fas up-right-from-square") -}}
 

--- a/layouts/_partials/assets/link.html
+++ b/layouts/_partials/assets/link.html
@@ -53,12 +53,13 @@
     {{- end -}}
     {{- if not $destination }}{{ $destination = "/" }}{{ end -}}
 
-    {{/* cue carries no schema default, so an absent value is nil and an explicit
-         false is a real choice. "default" treats false as empty and would silently
-         restore the site setting, so test for nil instead. */}}
+    {{/* cue and tab carry no schema default, so an absent value is nil and an
+         explicit false is a real choice. "default" treats false as empty and would
+         silently restore the site setting, so test for nil instead. */}}
     {{- $cue := site.Params.main.externalLinks.cue -}}
     {{- if ne $args.cue nil }}{{ $cue = $args.cue }}{{ end -}}
-    {{- $tab := $args.tab | default site.Params.main.externalLinks.tab -}}
+    {{- $tab := site.Params.main.externalLinks.tab -}}
+    {{- if ne $args.tab nil }}{{ $tab = $args.tab }}{{ end -}}
     {{- $externalLink := partial "utilities/GetThemeIcon.html" (dict "id" "externalLink" "default" "fas up-right-from-square") -}}
     {{- $pretty := site.Params.main.internalLinks.pretty | default false }}
     {{- $isExternal := or (ne (urls.Parse (absURL $destination)).Host (urls.Parse site.BaseURL).Host) $args.external -}}

--- a/layouts/_partials/assets/link.html
+++ b/layouts/_partials/assets/link.html
@@ -53,7 +53,11 @@
     {{- end -}}
     {{- if not $destination }}{{ $destination = "/" }}{{ end -}}
 
-    {{- $cue := $args.cue | default site.Params.main.externalLinks.cue -}}
+    {{/* cue carries no schema default, so an absent value is nil and an explicit
+         false is a real choice. "default" treats false as empty and would silently
+         restore the site setting, so test for nil instead. */}}
+    {{- $cue := site.Params.main.externalLinks.cue -}}
+    {{- if ne $args.cue nil }}{{ $cue = $args.cue }}{{ end -}}
     {{- $tab := $args.tab | default site.Params.main.externalLinks.tab -}}
     {{- $externalLink := partial "utilities/GetThemeIcon.html" (dict "id" "externalLink" "default" "fas up-right-from-square") -}}
     {{- $pretty := site.Params.main.internalLinks.pretty | default false }}

--- a/layouts/_partials/assets/links.html
+++ b/layouts/_partials/assets/links.html
@@ -102,6 +102,7 @@
                 "icon"      .icon
                 "outline"   .outline
                 "cue"       .cue
+                "tab"       .tab
                 "order"     (or .order $order)
                 "justify"   $justify
                 "link-type" $type

--- a/layouts/_partials/assets/links.html
+++ b/layouts/_partials/assets/links.html
@@ -101,6 +101,7 @@
                 "title"     $title
                 "icon"      .icon
                 "outline"   .outline
+                "cue"       .cue
                 "order"     (or .order $order)
                 "justify"   $justify
                 "link-type" $type


### PR DESCRIPTION
Setting `cue: false` or `tab: false` on an entry of a links list had no effect. Two independent defects sat in the way, and either one alone was enough to swallow the value.

**1. `assets/links.html` never forwarded them.** It passes `title`, `icon`, `outline` and `order` to `assets/button.html`, so the author's `cue`/`tab` never reached the consumer. They are forwarded on the button branch only — a download link is local by definition and `download.html` accepts neither argument.

**2. `| default` swallowed an explicit `false`.** `assets/button.html` and `assets/link.html` both resolved the value with:

```go-html-template
{{- $cue := $args.cue | default site.Params.main.externalLinks.cue -}}
```

Neither argument carries a schema default, so an absent value is `nil` and an explicit `false` is a deliberate choice — but Go's `default` treats `false` as empty and silently restored the site setting. This defeated `cue: false` even when passed **directly** to either partial, not just through a links list. Both now test for `nil` instead.

The motivating cases are a link that already carries its own brand icon (a LinkedIn button, where the external-link cue is redundant) and an external link that should stay in the current tab.

## Verification

- Direct probe against `assets/button.html` and `assets/link.html`: `cue: false` and `tab: false` are now honoured, while links that set neither still get the cue icon and `target="_blank"` from the site defaults.
- Applied to a production multilingual site on hinode v3.11.5: the four `cue: false` LinkedIn buttons go from 4/4 cued to 0/4 in both languages, a control set of external links stays 2/2 cued, and page counts and the rest of the build output are unchanged.
- `exampleSite` renders clean.

## Dependency

Includes `build(deps): bump mod-utils to v6.8.4`, which is where gethinode/mod-utils#359 landed — it declares `cue`/`tab` on the shared `links` item type so the attributes stop logging `warn-invalid-arguments` (`unsupported attribute`).

Not a functional dependency: the template changes work on v6.8.3, which is why the earlier commits passed CI on their own. The floor is raised so a release cannot ship the working overrides while still warning about them. `exampleSite` builds clean on v6.8.4 (98/26/24 pages, no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

