### PR TITLE
fix(i18n): translate the lightbox strings for all languages

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -233,6 +233,14 @@
   translation: "Absenden"
 - id: formBotField
   translation: "Bitte nicht ausfüllen, wenn Sie ein Mensch sind"
+
+# Lightbox
+- id: lightboxClose
+  translation: "Schließen"
+- id: lightboxLabel
+  translation: "Vergrößerte Ansicht"
+- id: lightboxExpand
+  translation: "Vollbild anzeigen"
 - id: tableFilterLabel
   translation: "Filter"
 - id: tableFilterAll

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -233,6 +233,14 @@
   translation: "Envoyer"
 - id: formBotField
   translation: "Ne remplissez pas ce champ si vous êtes humain"
+
+# Lightbox
+- id: lightboxClose
+  translation: "Fermer"
+- id: lightboxLabel
+  translation: "Vue agrandie"
+- id: lightboxExpand
+  translation: "Afficher en plein écran"
 - id: tableFilterLabel
   translation: "Filtre"
 - id: tableFilterAll

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -233,6 +233,14 @@
   translation: "Verzenden"
 - id: formBotField
   translation: "Vul dit niet in als je een mens bent"
+
+# Lightbox
+- id: lightboxClose
+  translation: "Sluiten"
+- id: lightboxLabel
+  translation: "Vergrote weergave"
+- id: lightboxExpand
+  translation: "Volledig scherm weergeven"
 - id: tableFilterLabel
   translation: "Filter"
 - id: tableFilterAll

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -233,6 +233,14 @@
   translation: "Wyślij"
 - id: formBotField
   translation: "Nie wypełniaj tego pola, jeśli jesteś człowiekiem"
+
+# Lightbox
+- id: lightboxClose
+  translation: "Zamknij"
+- id: lightboxLabel
+  translation: "Powiększony widok"
+- id: lightboxExpand
+  translation: "Wyświetl na pełnym ekranie"
 - id: tableFilterLabel
   translation: "Filtr"
 - id: tableFilterAll


### PR DESCRIPTION
The lightbox `<dialog>` added in this generation reads three i18n keys:

| Key | Used by |
|---|---|
| `lightboxLabel` | `assets/lightbox.html` — the dialog's `aria-label` |
| `lightboxClose` | `assets/lightbox.html` — the close button's `aria-label` |
| `lightboxExpand` | `assets/lightbox-trigger.html` — the trigger's `aria-label` |

All three ship in `i18n/en.yaml` only — `de`, `fr`, `nl` and `pl` have none of them. Every non-English site therefore logs `i18n MISSING_TRANSLATION` on each page and falls back to the raw key or English, on strings that are purely accessibility labels and so fail quietly.

This adds the three keys to the four remaining languages, in the same position and order as `en.yaml` (between `formBotField` and `tableFilterLabel`, under a `# Lightbox` comment).

## Translations

| | `lightboxClose` | `lightboxLabel` | `lightboxExpand` |
|---|---|---|---|
| en *(existing)* | Close | Enlarged view | View fullscreen |
| de | Schließen | Vergrößerte Ansicht | Vollbild anzeigen |
| fr | Fermer | Vue agrandie | Afficher en plein écran |
| nl | Sluiten | Vergrote weergave | Volledig scherm weergeven |
| pl | Zamknij | Powiększony widok | Wyświetl na pełnym ekranie |

`lightboxClose` reuses each file's existing `close` translation verbatim rather than inventing a synonym, and the verb forms follow each file's established style — de `…anzeigen`, fr `Afficher…`, pl imperative — so the wording sits consistently with its neighbours. A native check on `pl` would be welcome.

## Verification

- All five files parse, carry the same 100 keys, and contain no duplicate ids.
- Built a multilingual (en/nl) production site against the branch with `--printI18nWarnings`: the `nl|lightboxLabel` and `nl|lightboxClose` warnings drop to zero, and the rendered NL close button carries `aria-label="Sluiten"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)