### PR TITLE
fix(navbar): do not paint a background on a transparent navbar

### DIFF
--- a/layouts/_partials/assets/navbar.html
+++ b/layouts/_partials/assets/navbar.html
@@ -132,7 +132,10 @@
 <div class="container-fluid {{ if $args.fixed }}fixed-top{{ else if $overlay }}navbar-overlay{{ end }} p-0{{ with $class }} {{ . }}{{ end }}">
     {{- partial "assets/page-alert.html" (dict "page" $page) -}}
     <nav class="navbar {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }} navbar-fs-{{ $fs }} navbar-{{ $args.breakpoint }}-fs
-        {{- if not $overlay }}{{ with $color }} bg-{{ . }}{{ end }}{{ end -}}
+        {{/* An overlay or transparent navbar paints no solid background: the theme's own
+             `.navbar { background-color: transparent }` provides that, and a bg-* utility
+             would defeat it through Bootstrap's !important. */}}
+        {{- if and (not $overlay) (not $args.transparent) }}{{ with $color }} bg-{{ . }}{{ end }}{{ end -}}
         {{ if $args.fixed }} navbar-fixed-top{{ end }} navbar-expand-{{ $args.breakpoint -}}
         {{ if $contrast }} navbar-contrast{{ end }}"
         {{ if $overlay }}


### PR DESCRIPTION
`navigation.transparent = true` asks for a see-through navbar, and the theme already provides that with `.navbar { background-color: transparent }` in `components/_navbar.scss`. But `navbar.html` emitted `bg-{color}` regardless, and that Bootstrap utility carries `!important` — so it beat the theme’s own rule and the navbar stayed opaque.

Because `navigation.color` defaults to `"body"`, **every site that sets `transparent = true` without also blanking `color` gets an opaque navbar** — and the `backdrop-filter` blur that `transparent` exists to enable is invisible behind it, so the setting silently does nothing.

Blanking `color` was the only workaround. The `color` enum has no value meaning "none", so that meant passing an empty string and accepting a `warn-invalid-arguments` warning on *every page*:

```text
WARN  partial [assets/navbar.html] - Invalid arguments
	[navbar] argument 'color': unexpected value ''
```

## The change

One condition, mirroring what the same line already does for an overlay navbar — which paints no background for exactly the same reason:

```diff
-{{- if not $overlay }}{{ with $color }} bg-{{ . }}{{ end }}{{ end -}}
+{{- if and (not $overlay) (not $args.transparent) }}{{ with $color }} bg-{{ . }}{{ end }}{{ end -}}
```

No other state depends on that class: `.navbar-scrolled` only adds `backdrop-filter`, and `.nav-active` / `.navbar-expanded` set their own background in CSS via `--bs-navbar-expanded-color`. So the collapsed mobile menu and the scrolled frosted-glass state are unaffected.

## Verification

On a production multilingual site with `navigation.color` **removed entirely**:

| | Result |
|---|---|
| At rest | No `bg-*` class; computed background `rgba(0, 0, 0, 0)`; class list identical to the pre-v3 live site |
| Scrolled | Still gains `.navbar-scrolled` with `backdrop-filter: blur(10px)` over a translucent `rgba(227, 226, 225, 0.4)` wash |
| Build | Free of the per-page `argument 'color': unexpected value` warning, with no new warnings |

## Note

`$contrast` is still derived from `$color` a few lines above, so a transparent navbar with `color` set to one of primary/secondary/success/danger would keep `navbar-contrast` while painting no background. The existing `$overlay` branch has the same characteristic, so I have left it alone rather than guess whether that is deliberate — happy to fold it in if it should follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)