### PR TITLE
fix(navbar): let navigation.logo-align take effect

### DIFF
--- a/data/structures/navbar.yml
+++ b/data/structures/navbar.yml
@@ -80,8 +80,14 @@ arguments:
   logo-align:
     type: select
     optional: true
-    default: center
-    comment: Alignment of the logo when the navbar is in collapsed mode.
+    default:
+    comment: >-
+      Alignment of the logo when the navbar is in collapsed mode. The empty
+      `default:` is deliberate: a value here would be applied whenever a caller
+      omits the argument, which makes "not supplied" indistinguishable from
+      "supplied" and lets it override the `navigation.logo-align` site
+      parameter. `assets/navbar.html` supplies the "center" fallback instead,
+      so the effective default is unchanged.
     options:
       values:
         - start


### PR DESCRIPTION
## The defect

`assets/navbar.html` reads the site parameter and then lets the argument override it:

```go-html-template
{{ $align := index site.Params.navigation "logo-align" | default "center" }}
{{ with $args.logoAlign }}{{ $align = . }}{{ end }}
```

The schema carried `default: center`, so `Args.html` populated `$args.logoAlign` on **every** call, whether or not a caller supplied one. The second line therefore always fired, and the site parameter could never win.

`navigation.logo-align` was documented but inert. Setting it to `"start"` had no effect: the brand kept `mx-auto` below the navbar breakpoint, and the balancing invisible `navbar-toggler` was still emitted.

## The fix

Clearing the default restores the distinction between "not supplied" and "supplied". The effective default does not move — `assets/navbar.html` already supplies the `"center"` fallback, and `config/_default/params.toml` still ships `logo-align = "center"`.

## Verified on a consuming site — all three paths

**Site parameter unset** (backwards compatibility):

```text
class="navbar-brand mx-auto"     invisible fw-30 spacers: 1
```

Unchanged. This is the case that matters most, and it is why the fix is a cleared default rather than a removed line of template logic.

**`navigation.logo-align = "start"`**:

```text
class="navbar-brand"             invisible fw-30 spacers: 0
```

The brand sits at the leading edge and the balancing spacer is gone — both follow from `$align`, so one value drives both. A docs page still emits its real sidebar toggler (that slot is a separate branch, taken whenever a sidebar menu exists).

**`{{< navbar logo-align="center" >}}`** — the explicit argument still overrides the site parameter, verified on a page where the two disagree.

## Checks

`pnpm test` passes.