### PR TITLE
fix(table): scroll wide markdown tables instead of the page

### DIFF
--- a/layouts/_markup/render-table.html
+++ b/layouts/_markup/render-table.html
@@ -35,6 +35,15 @@
 
 {{ $align := dict "left" "start" "center" "center" "right" "end" }}
 
+{{/* Wrap in a horizontal-scroll container. A markdown table has no width budget
+     of its own, so a wide one pushes the page itself sideways at narrow widths
+     rather than scrolling within the column. `assets/table.html` already wraps
+     the `{{< table >}}` path this way; this brings markdown tables in line.
+
+     Additive: `overflow-x: auto` has no visual effect while the table fits, and
+     it composes with `table-wrap` above, which reduces the width rather than
+     scrolling it. */}}
+<div class="table-responsive">
 <table
   {{- range $k, $v := $attr }}
     {{- if $v }}
@@ -95,3 +104,4 @@
     {{- end }}
   </tbody>
 </table>
+</div>


### PR DESCRIPTION
## The defect

`assets/table.html` wraps the `{{< table >}}` path in `.table-responsive`, but the markdown render hook emitted a bare `<table>`. A markdown table has no width budget of its own, so a wide one pushed the **document** sideways at narrow widths rather than scrolling within its column.

Measured on a four-column docs table at a 390px viewport:

```text
before   table 422px, document 438px, page scrolls horizontally
after    table 422px inside a 358px scroll container, document 390px,
         page does not scroll
```

## Why this is low-risk

**Additive.** `overflow-x: auto` has no visual effect while the table fits. Verified on a table that does fit: renders unchanged at 358px, `scrollWidth === clientWidth`, no scrollbar.

**Composes with `table-wrap`.** That opt-in reduces the table's width by moving the last column to its own row; this scrolls whatever still overflows. Opting into both is coherent rather than conflicting.

**Uses the wrapper already in the codebase.** `assets/table.html` applies the same `.table-responsive`, so this brings the two table paths into agreement rather than introducing a new pattern.

No sticky positioning exists inside tables in this theme, so the new scroll container has nothing to clip.

## Checks

`pnpm test` passes. Verified against two consuming sites: a 2481-page docs site (the overflow case above) and a 1117-page marketing site (the fits-fine case).