### PR TITLE
fix(img): let an inlined SVG thumbnail fill its wrapper

### DIFF
--- a/assets/scss/components/_img.scss
+++ b/assets/scss/components/_img.scss
@@ -9,6 +9,20 @@
     object-fit: cover;
 }
 
+// `assets/image.html` inlines SVG sources, so an SVG thumbnail is never an
+// `<img>` and the rule above never reaches it. It falls back to its intrinsic
+// `width` attribute and sits flush left in a wider column -- a 640px asset
+// leaves 208px of dead space in an 848px column, narrower than the body text
+// it sits between.
+//
+// Fill the wrapper like a raster thumbnail. `height` follows the viewBox rather
+// than being forced to 100%: an SVG has no useful `object-fit` equivalent here,
+// and the aspect ratio is already carried by the viewBox.
+.img-wrap > svg {
+    width: 100%;
+    height: auto;
+}
+
 .card-img-h100 {
     width: auto;
     height: 100%;


### PR DESCRIPTION
## The defect

`.img-wrap img` already sets `width: 100%`, so a raster thumbnail fills its column. But `assets/image.html` **inlines** SVG sources — an SVG thumbnail is never an `<img>`, so that rule never reaches it. It falls back to its intrinsic `width` attribute and sits flush left.

Measured on a blog post at 1440px, a 640×360 asset in an 848px column:

```text
before   640x360, 208px of dead space on the right
after    848x477, flush with the column
```

The visible symptom is that the hero ends up **narrower than the body text it sits between**, which reads as a mistake rather than a deliberate inset. After the fix the hero edges land exactly on the paragraph edges — 296 → 1144 for both.

## Aspect ratio

`height` follows the viewBox rather than being forced to `100%`. An SVG has no useful `object-fit` equivalent here, and the viewBox already carries the ratio. Measured **1.778 before and after**.

## Scope

**Card thumbnails are untouched.** They use `.card-img-wrap`, a different wrapper — verified on a card grid where all four still fill their 432×243 frames exactly.

**Mobile is unaffected.** Below the asset's intrinsic width the existing `max-width: 100%` floor was already capping it, so 390px renders 358×201 with or without this change. The fix only alters the case where the wrapper is *wider* than the asset.

**Only page-level thumbnails.** On the site used for verification, exactly 4 pages carry `.img-wrap > svg` (the blog posts) and 0 carry `.img-wrap > img`, so nothing else moves.

## Checks

`pnpm test` passes. Verified against a 1117-page site at 1440px and 390px, plus a card-grid page for the no-regression case.