### PR TITLE
refactor(navbar): drop the redundant mode-toggle icon width rule

### DIFF
--- a/assets/scss/components/_navbar.scss
+++ b/assets/scss/components/_navbar.scss
@@ -80,11 +80,6 @@ $theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out,
 	cursor: pointer;
 }
 
-.mode-toggle .label svg {
-    height: 1em;
-    width: 1.25em;
-}
-
 // Source: https://jsfiddle.net/njhgr40m/
 
 @if $enable-dark-mode {


### PR DESCRIPTION
Follow-up to [mod-fontawesome#350](https://github.com/gethinode/mod-fontawesome/pull/350). Deletes a workaround that only existed because `fa-fw` did nothing on inline SVG.

## Why it existed

FontAwesome v7 sets `.fa-fw{--fa-width:1.25em}` and only the **webfont** rule consumed the property. mod-fontawesome's inline-SVG rule hard-set `width: auto`, so `fa-fw` was inert — and since Hinode renders icons as inline SVG, that was every icon.

`.mode-toggle .label svg { height: 1em; width: 1.25em }` compensated for exactly one row. The other navbar controls had no equivalent, which is why the theme toggle and the search/profile rows rendered at different widths and their labels did not line up.

## Why it is now redundant

mod-fontawesome v6.1.4 makes the inline-SVG rule read the property, so the base styles produce this geometry unaided:

- `height: 1em` from `.svg-inline--fa`
- `width: 1.25em` from the `fa-fw` that `assets/helpers/navbar-mode.html` already emits

## Verified

Built a consuming site with and without this rule at 390px, where the controls form a labelled column:

```text
                with rule     without rule
toggle icon     20x16         20x16
profile icon    20x16         20x16
label origin    x=42          x=42
```

Identical. The rows also now agree with each other, which they did not before v6.1.4.

Pill mode (`toggle = false`, the default) checked separately: both icons render 16x14 inside the 43px pill, `scrollWidth == clientWidth`, no overflow.

## Compatibility

**Requires mod-fontawesome >= v6.1.4.** Before that, this rule is load-bearing for the toggle.

## Left alone deliberately

`.mode-switch .fa-moon` and `.fa-sun` set colour and scale rather than width, and they match whenever a site keeps the default `fas sun` / `fas moon` icons. They are inert only on sites configuring a different icon set — a site choice, not dead code here.

## Checks

`pnpm test` passes.