### PR TITLE
fix(sidebar): align a group's children with its label, not its icon

### DIFF
--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -584,6 +584,23 @@ html.sidebar-pre-collapsed .sidebar-collapsible .sidebar-footer .sidebar-seconda
     transform: translateX(-50%);
 }
 
+// Align a group's children with its label rather than its icon.
+//
+// A leading icon pushes the parent's own label right by the icon's width plus
+// its `me-1` gutter. The nested list only carries `ps-3`, which is narrower
+// than that, so without this the children sit slightly to the *left* of the
+// label they belong to and the hierarchy reads as broken.
+//
+// Scoped with `:has()` so a sidebar without icons keeps the plain `ps-3`
+// indent, and so it holds however the icon arrived — a `pre` field on a
+// data-file menu or a page's `icon` param via `navigation.sidebarIcons`.
+// Only the first nested list needs shifting: everything deeper is indented
+// relative to it and follows.
+li:has(> .sidebar-item-group svg.svg-inline--fa) > .collapse > .btn-toggle-nav {
+    // Matches `fa-fw` (--fa-width: 1.25em) plus the icon's `me-1` gutter.
+    padding-left: calc(1.25rem + 0.25rem) !important;
+}
+
 // scss-docs-end sidebar
 
 .dropdown-toggle {


### PR DESCRIPTION
Follow-on to #2102, found on a consuming site's deploy preview: with icons on, a group's children sit slightly **left** of the label they belong to, and the hierarchy reads as broken.

## Cause

A leading icon pushes the parent's own label right by the icon width plus its `me-1` gutter — **24px** at the default size. The nested list only carries `ps-3`, which is **16px**. The children are therefore 8px short of their parent's label.

## The fix

```scss
li:has(> .sidebar-item-group svg.svg-inline--fa) > .collapse > .btn-toggle-nav {
    padding-left: calc(1.25rem + 0.25rem) !important;   // fa-fw width + me-1
}
```

`:has()` is already used in this file (`_sidebar.scss:540`) and in `_card.scss`, so it introduces no new idiom.

Scoping it this way means it holds **however the icon arrived** — a `pre` field on a data-file menu, or a page's `icon` via `navigation.sidebarIcons` — with no template or config change. Only the first nested list needs shifting; everything deeper is indented relative to it and follows.

## Evidence

Icon on the top level only, reading the first visible glyph of each row:

| Row | Before | After |
| --- | --- | --- |
| `Guides` (has icon) | 104 | 104 |
| `Organization` | **96** | **104** |
| `Invite a Member` | 112 | 120 |

`Organization` now starts exactly where its parent's label does, which was the reported problem.

## No-op without icons

The risk in touching a shared sidebar is the sidebars that were already fine. I removed the icons from the same site and rebuilt: the ladder stays **80 / 96 / 112** and nested lists keep their **16px** padding, so `:has()` never matches and nothing moves.

`pnpm test` passes.
