### PR TITLE
feat(styles): make the cover section height configurable

### DIFF
--- a/assets/scss/common/_styles.scss
+++ b/assets/scss/common/_styles.scss
@@ -59,8 +59,16 @@ body {
 .main {
     --navbar-height: #{$navbar-height};
     --overlay-offset: #{$overlay-offset};
-    --section-height: 88vh;
-    --max-section-height: 1024px;
+
+    // Height of a cover section (`cover: true`), set from `main.sectionHeight`.
+    // The default 88vh deliberately falls short of the viewport so the next
+    // section peeks above the fold and invites scrolling; set it to 100vh for a
+    // true full-screen hero. `--max-section-height` (`main.maxSectionHeight`)
+    // caps it on xxl and tall viewports — raise that too, or a 100vh section
+    // still stops at 1024px there. Both are plain custom properties, so a
+    // downstream theme can also override them per page or per section.
+    --section-height: #{$section-height};
+    --max-section-height: #{$max-section-height};
 
     flex: 1;
 }

--- a/assets/scss/common/_variables-dart.scss
+++ b/assets/scss/common/_variables-dart.scss
@@ -28,6 +28,8 @@ $navbar-offset-xs:              h.$navbar-offset-xs;
 $navbar-size:                   h.$navbar-size;
 $main-breakpoint:               h.$main-breakpoint;
 $overlay-offset:                h.$overlay-offset;
+$section-height:                h.$section-height;
+$max-section-height:            h.$max-section-height;
 $primary:                       h.$primary;
 $secondary:                     h.$secondary;
 $success:                       h.$success;

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -8,6 +8,8 @@
     footerBelowFold = false
     loading = "lazy"
     breakpoint = "md"
+    sectionHeight = "88vh"
+    maxSectionHeight = "1024px"
     titleCase = false
     titleCaseExceptions = []
     [main.padding]

--- a/layouts/_partials/head/stylesheet.html
+++ b/layouts/_partials/head/stylesheet.html
@@ -65,6 +65,8 @@
     "navbar-size"             (site.Params.navigation.size | default "md")
     "main-breakpoint"         (site.Params.main.breakpoint | default "md")
     "overlay-offset"          $overlayOffset
+    "section-height"          (site.Params.main.sectionHeight | default "88vh")
+    "max-section-height"      (site.Params.main.maxSectionHeight | default "1024px")
     "enable-dark-mode"        (printf "%t" ((default true (or site.Params.main.enableDarkMode site.Params.main.colorMode.enabled))))
     "import-fonts"            (printf "%t" (not (hasPrefix (lower site.Params.style.themeFontPath) "http")))
     "dark-mode-shade"         (default "0%" site.Params.style.darkModeShade)


### PR DESCRIPTION
Fixes #2107.

## Analysis

`cover: true` was working. A cover section is **88vh**, not 100vh — the reporter's screenshot measures out to exactly that.

| | |
|---|---|
| `_styles.scss:62` | `--section-height: 88vh` |
| `_styles.scss:86` | `main:has(section:first-of-type.section-cover) { margin-top: var(--overlay-offset) }` |
| `_styles.scss:124` | `.section-cover { min-height: calc(var(--section-height) - var(--overlay-offset)) }` |

Total = `overlay-offset + (88vh − overlay-offset)` = **88vh**, independent of navbar height. Measuring the reported screenshot: viewport 1900×1031, hero/next-section boundary at y=907 → 87.97%. `--max-section-height: 1024px` shrinks that share further from `xxl` upwards and above 1400px tall.

Not a regression — `git diff v3.14.1 HEAD` on that file shows only the unrelated `.title-case` addition, and `88vh` has been there since 7f7c8d1 (2025-06-18).

The 12vh shortfall is clearly deliberate: it lets the next section peek above the fold. The problem is that it was hardcoded, undocumented, and had no supported override, while three separate places promised "fullscreen".

## Change

Expose `main.sectionHeight` and `main.maxSectionHeight`, plumbed through `head/stylesheet.html` alongside the existing navbar offsets. **Defaults are unchanged** — no existing site shifts.

## Verification

Built the exampleSite (Hugo 0.164.0, the reporter's version) with a `cover: true` hero, measured in a real browser at their exact 1900×1031 viewport:

| Config | Hero bottom edge | % of viewport |
|---|---|---|
| defaults | 907px | **88.0%** (reproduces the report) |
| `sectionHeight`/`maxSectionHeight = "100vh"` | 1031px | **100.0%** |

`lint:styles` and `test:templates` pass.

The libsass path shares the same `$vars` dict as the adjacent `$overlay-offset`, so nothing there is transpiler-specific beyond the `h.` bridge added to `_variables-dart.scss`. It could not be exercised end-to-end: libsass already fails in the exampleSite for unrelated pre-existing reasons (FontAwesome v7 requires DartSass; `mod-blocks/preview.scss:58` uses a `min()` libsass rejects).

## Related

- gethinode/mod-blocks — forwards the `cover` flag into the hero body partial
- gethinode/mod-docs — corrects the "full-page hero" wording
- gethinode/mod-utils — corrects the shared `cover` argument description
- gethinode/gethinode.com — documents the two new settings (held for this release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)