### PR TITLE
fix(seo): build breadcrumb schema from page ancestry

### DIFF
--- a/layouts/_partials/head/structured-data.html
+++ b/layouts/_partials/head/structured-data.html
@@ -1,21 +1,22 @@
 {{/* Copied from doks */}}
 {{ $baseURL := "/" | absURL -}}
 
-{{ $dot := . -}}
-{{ $dot.Scratch.Set "path" "" -}}
-{{ $dot.Scratch.Set "breadcrumb" slice -}}
-
-{{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" -}}
-{{ $.Scratch.Add "path" .Site.BaseURL -}}
-
-{{ $.Scratch.Add "breadcrumb" (slice (dict "url" .Site.BaseURL "name" "home" "position" 1 )) -}}
-  {{ range $index, $element := split $url "/" -}}
-    {{ $dot.Scratch.Add "path" $element -}}
-    {{ $.Scratch.Add "path" "/" -}}
-    {{ if ne $element "" -}}
-    {{ $.Scratch.Add "breadcrumb" (slice (dict "url" ($.Scratch.Get "path") "name" . "position" (add $index 2))) -}}
-  {{ end -}}
+{{/* Build the breadcrumb trail from the page ancestry. Reconstructing it by trimming
+     baseURL off .Permalink and splitting the remainder breaks on a relative baseURL:
+     `replace` is global, so a baseURL of "/" strips every separator in the path and the
+     trail collapses to a single mangled entry. .Ancestors is independent of how baseURL
+     is configured, and carries each page's LinkTitle rather than a URL segment. */ -}}
+{{ $breadcrumb := slice -}}
+{{ range .Ancestors.Reverse -}}
+  {{ $breadcrumb = $breadcrumb | append (dict
+      "url" .Permalink
+      "name" (cond .IsHome (T "home") .LinkTitle)
+      "position" (add (len $breadcrumb) 1)) -}}
 {{ end -}}
+{{ $breadcrumb = $breadcrumb | append (dict
+    "url" .Permalink
+    "name" (cond .IsHome (T "home") .LinkTitle)
+    "position" (add (len $breadcrumb) 1)) -}}
 
 {{ $alt := slice .Site.Params.schema.twitter .Site.Params.schema.linkedin .Site.Params.schema.github }}
 
@@ -112,18 +113,14 @@
       "@type": "BreadcrumbList",
       "@id": {{ print .Permalink "#/schema/breadcrumb/1" }},
       "name": "Breadcrumbs",
-      "itemListElement": [{{ $list := $.Scratch.Get "breadcrumb" }}{{ $len := (len $list) }}{{ range $index, $element := $list }}{{ if ne .position 1 }},{{ end }}{
+      "itemListElement": [{{ range $index, $element := $breadcrumb }}{{ if $index }},{{ end }}{
         "@type": "ListItem",
         "position": {{ .position }},
         "item": {
-          {{ if ne (add $index 1) $len -}}
           "@type": "WebPage",
           "@id": {{ .url }},
           "url": {{ .url }},
-          "name": "{{ .name | humanize | title }}"
-          {{ else -}}
-          "@id": {{ .url }}
-          {{ end -}}
+          "name": {{ .name }}
         }
         }{{ end }}]
     },


### PR DESCRIPTION
## Problem

Two defects in the `BreadcrumbList` emitted by `layouts/_partials/head/structured-data.html`.

**1. The trail collapses when `baseURL` is relative.** The trail was reconstructed by trimming `baseURL` off `.Permalink` and splitting the remainder:

```go-html-template
{{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" -}}
```

`replace` is global, so a `baseURL` of `/` strips *every* separator from the path. `/docs/guides/catalog/` becomes `docsguidescatalog`, which splits into a single segment, and the whole trail collapses to one entry with a mangled URL:

```json
"itemListElement": [
  { "position": 1, "item": { "@id": "/", "url": "/", "name": "Home" } },
  { "position": 2, "item": { "@id": "/docsguidescatalog/" } }
]
```

Sites with an absolute `baseURL` are unaffected by this one, which is why it has gone unnoticed — the theme's own site and exampleSite both set one.

**2. The last item has no `name`.** The emitter's `else` branch produced `item: { "@id": … }` and nothing else. This affects **every** site regardless of `baseURL`. Google requires a `name` on each `ListItem`, so the breadcrumb is ineligible for rich results as emitted.

## Fix

Derive the trail from `.Ancestors` rather than by slicing the permalink:

- independent of how `baseURL` is configured
- carries each page's `LinkTitle` instead of a humanized URL segment, so `/docs/` now reads as its actual title ("Documentation") rather than "Docs"
- emits `@type`, `@id`, `url` and `name` for every item, including the last
- drops `humanize | title`, which was only needed while names came from slugs and would mangle deliberate casing (`gRPC API` → `Grpc Api`)
- emits the name unquoted so Hugo escapes it as a JSON string literal; a title containing a `"` previously produced invalid JSON-LD

`.Scratch` is no longer used for `breadcrumb`/`path` — no other template read those keys.

## Verification

Built a downstream site (405 pages) against the patched partial in both modes and parsed the emitted JSON-LD on seven page kinds — home, section, nested page, 3-level docs page, generated page, taxonomy term, and list:

| | before | after |
|---|---|---|
| relative `baseURL` | `Home(/) > None(None)` on all seven | `Home > Documentation > Guides > Catalog`, every item named |
| absolute `baseURL` | correct chain, last item nameless | every item named |

All emitted JSON parses, positions are sequential from 1, no malformed URLs. `tests/templates` passes, and the theme's own site build emits a valid trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)