### PR TITLE
feat(table): add justify for the filter controls

### DIFF
--- a/data/structures/table.yml
+++ b/data/structures/table.yml
@@ -29,6 +29,12 @@ arguments:
     release: v0.24.13
   filter:
   filter-col:
+  justify:
+    comment: >-
+      Horizontal alignment of the filter controls. Requires `filter`, which is
+      the only element this argument positions — the table itself always spans
+      the full width of its container.
+    release: v3.18.0
   wrap:
   wrapper:
     release: v2.0.0

--- a/exampleSite/content/en/table-demo.md
+++ b/exampleSite/content/en/table-demo.md
@@ -49,6 +49,18 @@ modules: ["simple-datatables"]
 | delta   | gadget | The fourth record, whose description runs on for a little while.   |
 {{< /table >}}
 
+## Centered filter controls
+
+{{< table filter="widget, gadget" filter-col="1" justify="center" class="fixture-filter-center" >}}
+
+| Name    | Type   | Description                                                        |
+|---------|--------|--------------------------------------------------------------------|
+| alpha   | widget | The first record, with a description long enough to need wrapping. |
+| bravo   | gadget | The second record, also with a fairly long trailing description.   |
+| charlie | widget | The third record. Short.                                           |
+| delta   | gadget | The fourth record, whose description runs on for a little while.   |
+{{< /table >}}
+
 ## Filtered, sortable, wrapped data table
 
 {{< table filter="widget,gadget" filter-col="1" sortable="true" paginate="true" pagination="2" wrap="true" class="fixture-filter-wrap" >}}

--- a/layouts/_partials/assets/table.html
+++ b/layouts/_partials/assets/table.html
@@ -126,8 +126,11 @@
 
     {{ $wrapper := $args.wrapper | default "" }}
 
+    {{/* The controls sit in their own flex row, so they align independently of the table below —
+         which always spans the full width of its container. `justify` carries a default of
+         `start` in mod-utils, preserving the original alignment for every existing caller. */}}
     {{ if $filter }}
-    <div class="table-filter-controls d-flex justify-content-start mb-3">
+    <div class="table-filter-controls d-flex justify-content-{{ $args.justify }} mb-3">
         <div class="btn-group" role="group" aria-label="{{ T "tableFilterLabel" | default "Filter" }}">
             <button type="button"
                     class="btn btn-outline-primary active"

--- a/layouts/_shortcodes/table.html
+++ b/layouts/_shortcodes/table.html
@@ -74,6 +74,7 @@
         "searchable"             $args.searchable
         "filter"                 $args.filter
         "filter-col"             $args.filterCol
+        "justify"                $args.justify
         "wrap"                   $args.wrap
         "wrapper"                $args.wrapper
         "caption"                $args.caption


### PR DESCRIPTION
## Problem

The table's filter bar hardcoded `justify-content-start`:

```html
<div class="table-filter-controls d-flex justify-content-start mb-3">
```

A caller that centers a table's section therefore gets a centered heading above a flush-left button group, with no argument available to correct it. `utilities/section.html` applies `justify` as `align-items-*` to the column as a whole — with a `width` set, that centers the column and leaves its contents flush left, while `section-title.html` separately centers the heading via `mx-auto`. The table half never received it.

Reported against the `list` block in a downstream site, whose `justify: center` produced exactly that mismatch.

## Change

Three gaps had to close for the argument to reach the markup:

| File | Gap |
|---|---|
| `data/structures/table.yml` | no `justify` argument existed, so there was no override to pass |
| `layouts/_partials/assets/table.html` | hardcoded `justify-content-start` |
| `layouts/_shortcodes/table.html` | forwards arguments one by one — without the new key, `justify` validates and is then **silently dropped** |

The argument reuses the shared definition from mod-utils, so it inherits the `start` default and the `start`/`end`/`center`/`between`/`around`/`evenly` option set. Those map 1:1 onto `justify-content-*`. Only `comment` and `release` are overridden locally, which keeps `type`, `options`, and `default` intact.

Only the filter row is positioned. The table itself spans the full width of its container either way.

## Compatibility

None for existing callers: the shared `start` default reproduces the previous hardcoded value.

## Verification

`pnpm test` passes (lint + template tests).

A `fixture-filter-center` case was added to `exampleSite/content/en/table-demo.md`. It was written **before** the fix and failed with `[table] unsupported argument 'justify'` — which is how the dropped-shortcode-argument gap surfaced, since the build went green while the markup still rendered `start`.

Rendered output of `exampleSite/content/en/table-demo.md` after the fix:

```
class="table-filter-controls d-flex justify-content-start mb-3"    <- fixture-filter (unchanged)
class="table-filter-controls d-flex justify-content-center mb-3"   <- fixture-filter-center (new)
class="table-filter-controls d-flex justify-content-start mb-3"    <- fixture-filter-wrap (unchanged)
```

Also verified end-to-end in a downstream site by patching its vendored copy: the reported page renders `justify-content-center`.

## Release coordination

Typed as `feat` so this lands as a minor bump, matching how `caption` was added in v3.12.0 and the `release: v3.18.0` annotation on the new argument.

gethinode/mod-blocks#192 forwards `justify` from the `list` block and **depends on this release**. `InitArgs` rejects an unknown key regardless of its value, so until mod-blocks' exampleSite bumps to v3.18.0 that change breaks every list block. Merge and release this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)