### PR TITLE
feat(a11y): give content blocks a heading level

### DIFF
--- a/assets/scss/layouts/_type.scss
+++ b/assets/scss/layouts/_type.scss
@@ -34,3 +34,10 @@ h6 {
 .display-1, .display-2, .display-3, .display-4, .display-5, .display-6 {
     scroll-margin-top: var(--navbar-offset);
 }
+
+// Section titles reset their element margins so a heading occupies the same box as the div it
+// replaces. A list page's own title opts back in to the spacing the h1 rule above provides.
+.section-title-lead {
+    margin-top: $spacer * 2.5;
+    margin-bottom: $spacer * 0.5;
+}

--- a/assets/scss/layouts/_type.scss
+++ b/assets/scss/layouts/_type.scss
@@ -34,10 +34,3 @@ h6 {
 .display-1, .display-2, .display-3, .display-4, .display-5, .display-6 {
     scroll-margin-top: var(--navbar-offset);
 }
-
-// Section titles reset their element margins so a heading occupies the same box as the div it
-// replaces. A list page's own title opts back in to the spacing the h1 rule above provides.
-.section-title-lead {
-    margin-top: $spacer * 2.5;
-    margin-bottom: $spacer * 0.5;
-}

--- a/data/structures/section-title.yml
+++ b/data/structures/section-title.yml
@@ -12,6 +12,22 @@ arguments:
   class:
   size:
   use-title:
+  heading-level:
+    type: int
+    optional: true
+    release: v3.19.0
+    comment: >-
+      Heading level of the title, from 1 (h1) to 6 (h6). Defaults to 0, which
+      renders a div instead of a heading. Content blocks receive a level from
+      the page that renders them, so the first titled block of a page without a
+      page header becomes its h1.
+  heading-class:
+    type: string
+    optional: true
+    release: v3.19.0
+    comment: >-
+      Classes for the heading element. Replaces the margin reset that otherwise
+      keeps a heading aligned with the div it succeeds.
   justify:
   link-type:
   use-section:

--- a/data/structures/section-title.yml
+++ b/data/structures/section-title.yml
@@ -26,8 +26,10 @@ arguments:
     optional: true
     release: v3.19.0
     comment: >-
-      Classes for the heading element. Replaces the margin reset that otherwise
-      keeps a heading aligned with the div it succeeds.
+      Classes for the heading element, applied only when a heading level renders
+      one. Replaces the margin reset that otherwise keeps a title raised by
+      heading-level aligned with the div it succeeds; pass an empty string to
+      leave the element on its own styling.
   justify:
   link-type:
   use-section:

--- a/layouts/_partials/assets/section-title.html
+++ b/layouts/_partials/assets/section-title.html
@@ -46,7 +46,8 @@
 {{/* Read the heading level. An explicit heading-level wins, the legacy use-title boolean maps onto
      level 1, and a caller that asks for neither keeps the div this partial has always rendered. */}}
 {{- $level := $args.headingLevel -}}
-{{- if eq $level nil }}{{ $level = cond $args.useTitle 1 0 }}{{ end -}}
+{{- $levelled := ne $level nil -}}
+{{- if not $levelled }}{{ $level = cond $args.useTitle 1 0 }}{{ end -}}
 {{- if or (lt $level 0) (gt $level 6) -}}
     {{- partial "utilities/LogWarn.html" (dict
         "partial" "assets/section-title.html"
@@ -58,12 +59,18 @@
     {{- $level = 0 -}}
 {{- end -}}
 
-{{/* A heading carries margins that the div it replaces does not, and with the "fs" heading style
-     it also picks up Bootstrap's heading weight and line height. Reset those so the element
-     occupies the same box at every level, unless the caller supplies its own classes. */}}
-{{- $reset := "mt-0 mb-0" -}}
-{{- if eq $headingStyle "fs" }}{{ $reset = printf "%s fw-normal lh-base" $reset }}{{ end -}}
-{{- $headingClass := $args.headingClass | default $reset -}}
+{{/* Classes for the heading element. A caller-supplied heading-class always wins, including an
+     empty string, which leaves the element on its own styling. Without one, a heading-level title
+     resets the margins that a heading carries and the div it replaces does not, plus the weight
+     and line height that the "fs" heading style leaves to Bootstrap; a use-title title keeps the
+     styling the h1 has always had. */}}
+{{- $headingClass := "" -}}
+{{- if isset $args "headingClass" -}}
+    {{- $headingClass = $args.headingClass -}}
+{{- else if $levelled -}}
+    {{- $headingClass = "mt-0 mb-0" -}}
+    {{- if eq $headingStyle "fs" }}{{ $headingClass = printf "%s fw-normal lh-base" $headingClass }}{{ end -}}
+{{- end -}}
 
 {{ $preheading = partial "utilities/TitleCase.html" (dict "page" $page "text" $preheading) }}
 {{ $title = partial "utilities/TitleCase.html" (dict "page" $page "text" $title) }}

--- a/layouts/_partials/assets/section-title.html
+++ b/layouts/_partials/assets/section-title.html
@@ -43,32 +43,60 @@
 {{- if and (not $preheading) $args.useSection }}{{ $preheading = $page.CurrentSection.Name }}{{ end -}}
 {{- $justify := cond (eq $args.justify "start") "" (cond (eq $args.justify "end") "me-0" "mx-auto") -}}
 
+{{/* Read the heading level. An explicit heading-level wins, the legacy use-title boolean maps onto
+     level 1, and a caller that asks for neither keeps the div this partial has always rendered. */}}
+{{- $level := $args.headingLevel -}}
+{{- if eq $level nil }}{{ $level = cond $args.useTitle 1 0 }}{{ end -}}
+{{- if or (lt $level 0) (gt $level 6) -}}
+    {{- partial "utilities/LogWarn.html" (dict
+        "partial" "assets/section-title.html"
+        "warnid"  "warn-invalid-heading-level"
+        "msg"     (printf "Heading level %d is out of range, falling back to a div" $level)
+        "details" (slice "Use a level between 1 and 6, or 0 to render a div")
+        "file"    $page.File
+    ) -}}
+    {{- $level = 0 -}}
+{{- end -}}
+
+{{/* A heading carries margins that the div it replaces does not, and with the "fs" heading style
+     it also picks up Bootstrap's heading weight and line height. Reset those so the element
+     occupies the same box at every level, unless the caller supplies its own classes. */}}
+{{- $reset := "mt-0 mb-0" -}}
+{{- if eq $headingStyle "fs" }}{{ $reset = printf "%s fw-normal lh-base" $reset }}{{ end -}}
+{{- $headingClass := $args.headingClass | default $reset -}}
+
 {{ $preheading = partial "utilities/TitleCase.html" (dict "page" $page "text" $preheading) }}
 {{ $title = partial "utilities/TitleCase.html" (dict "page" $page "text" $title) }}
 
+{{/* Composes the title element. The tag varies with the heading level, and Go's template engine
+     rejects a dynamic element name, so the markup is assembled as a string and marked safe. */}}
 {{ define "_partials/assets/section-title-header.html" }}
-    {{- $page := .page }}
-    {{ $headingStyle := .headingStyle }}
+    {{- $page := .page -}}
+    {{- $level := .level -}}
+    {{- $tag := cond (eq $level 0) "div" (printf "h%d" $level) -}}
 
-    {{ if (index . "use-title") }}
-        {{ $title := .title | $page.RenderString }}
-        {{ $label := trim (replaceRE "\r\n?|\n" " " ($title | plainify)) " " }}
-        <h1 id="{{ anchorize .title }}" {{ if ne $title $label }}aria-label="{{ $label }}"{{ end -}}
-            class="{{ $headingStyle }}-{{ .size }}{{ with .color }} text-{{ . }}{{ end }} pt-1">
-                {{ .title | $page.RenderString | safeHTML }}
-        </h1>
-    {{ else }}
-        <div id="{{ anchorize .title }}" class="{{ $headingStyle }}-{{ .size }}{{ with .color }} text-{{ . }}{{ end }} pt-1">
-            {{ .title | $page.RenderString | safeHTML }}
-        </div>
-    {{ end }}
+    {{- $title := .title | $page.RenderString -}}
+    {{- $label := trim (replaceRE "\r\n?|\n" " " ($title | plainify)) " " -}}
+
+    {{- $class := printf "%s-%v" .headingStyle .size -}}
+    {{- with .color }}{{ $class = printf "%s text-%s" $class . }}{{ end -}}
+    {{- $class = printf "%s pt-1" $class -}}
+    {{- if ne $level 0 }}{{ with .headingClass }}{{ $class = printf "%s %s" $class . }}{{ end }}{{ end -}}
+
+    {{- $attrs := printf `id="%s" class="%s"` (anchorize .title) $class -}}
+    {{- if and (ne $level 0) (ne $title $label) -}}
+        {{- $attrs = printf `id="%s" aria-label="%s" class="%s"` (anchorize .title) (htmlEscape $label) $class -}}
+    {{- end -}}
+
+    {{- printf "<%s %s>\n%s\n</%s>" $tag $attrs $title $tag | safeHTML -}}
 {{ end }}
 
 {{ $header := "" }}
 {{ if $title }}
     {{ $header = partial "assets/section-title-header.html" (dict
         "page"         $page
-        "use-title"    $args.useTitle
+        "level"        $level
+        "headingClass" $headingClass
         "title"        $title
         "headingStyle" $headingStyle
         "color"        $args.color

--- a/layouts/_partials/page/articles.html
+++ b/layouts/_partials/page/articles.html
@@ -24,8 +24,9 @@
         "content" .Description
         "align"   "start"
     )
-    "use-title" true
-    "action"    $sectionAction
+    "heading-level" 1
+    "heading-class" "section-title-lead"
+    "action"        $sectionAction
 ) }}
 
 {{/* Init the card styling */}}

--- a/layouts/_partials/page/articles.html
+++ b/layouts/_partials/page/articles.html
@@ -17,6 +17,8 @@
 {{ if .Site.Params.navigation.breadcrumb }}
     {{ partial "assets/breadcrumb.html" (dict "page" .) }}
 {{ end }}
+{{/* The empty heading-class keeps this title on the h1 element's own spacing, rather than the
+     reset that aligns a promoted block title with the div it replaces. */}}
 {{ partial "assets/section-title.html" (dict
     "page"    .
     "heading" (dict
@@ -25,7 +27,7 @@
         "align"   "start"
     )
     "heading-level" 1
-    "heading-class" "section-title-lead"
+    "heading-class" ""
     "action"        $sectionAction
 ) }}
 

--- a/layouts/docs/all.html
+++ b/layouts/docs/all.html
@@ -23,7 +23,8 @@
             <div class="col-12 col-{{ $breakpoint.current }}-9 col-{{ $breakpoint.next }}-8 mb-5">
                 {{/* Render the defined content blocks, using the default articles element as fallback for list pages */}}
                 {{ if .Params.content_blocks }}
-                    {{- partial "page/blocks.html" (dict "page" . "embed" true) -}}
+                    {{/* Blocks replace the page header here, so they own the h1 */}}
+                    {{- partial "page/blocks.html" (dict "page" . "embed" true "heading-level" 1) -}}
                 {{ else if eq .Kind "section" }}
                     {{ $.Scratch.Set "articlesParams" (dict
                         "sort"         "weight"

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -5,7 +5,8 @@
 
     <!-- Render the defined content blocks, using the default articles element as fallback -->
     {{ if .Params.content_blocks }}
-        {{- partial "page/blocks.html" . -}}
+        {{/* Blocks replace the page header here, so they own the h1 */}}
+        {{- partial "page/blocks.html" (dict "page" . "heading-level" 1) -}}
     {{ else }}
         {{ with partial "page/articles.html" . }}
             <div class="container-xxl {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "y") }} px-xxl-0 {{ partial "utilities/PaddingClasses.html" (dict "padding" $padding "axis" "x") }} py-0 my-auto h-100">

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -5,7 +5,13 @@
 
     {{/* Render the offcanvas sidebar and content blocks */}}
     {{- partial "page/sidebar-offcanvas.html" (dict "section" $.Section "raw" $sidebar) -}}
-    {{- partial "page/blocks.html" . -}}
+
+    {{/* The header below renders only for a page that carries content, and it owns the h1 when it
+         does. Tell the blocks which level to start at so the page has exactly one. */}}
+    {{- partial "page/blocks.html" (dict
+        "page"          .
+        "heading-level" (cond (gt (len .RawContent) 0) 2 1)
+    ) -}}
 
     {{/* Render the single page content using responsive columns */}}
     {{/*    Column 1: sidebar navigation, visible in medium viewports and above (uses offcanvas on small devices) */}}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -7,7 +7,9 @@
     {{- partial "page/sidebar-offcanvas.html" (dict "section" $.Section "raw" $sidebar) -}}
 
     {{/* The header below renders only for a page that carries content, and it owns the h1 when it
-         does. Tell the blocks which level to start at so the page has exactly one. */}}
+         does, so blocks start at 2 there and at 1 otherwise. Blocks render ahead of that header,
+         so a page carrying both leads with its block titles at level 2 and reaches its h1 below
+         them. */}}
     {{- partial "page/blocks.html" (dict
         "page"          .
         "heading-level" (cond (gt (len .RawContent) 0) 2 1)

--- a/tests/templates/hugo.toml
+++ b/tests/templates/hugo.toml
@@ -36,3 +36,21 @@ disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
 [[module.mounts]]
   source = '../../layouts/_partials/utilities/GetIncludeTOC.html'
   target = 'layouts/_partials/utilities/GetIncludeTOC.html'
+
+# assets/section-title.html initializes its arguments through mod-utils (InitArgs and the
+# structure data it reads), so those come from the vendored module — `mod:vendor` populates
+# `_vendor` and CI runs it before `test:templates`. The two `data/structures` mounts merge:
+# the theme file provides the section-title structure, the module directory provides the
+# global argument and type definitions it inherits from.
+[[module.mounts]]
+  source = '../../layouts/_partials/assets/section-title.html'
+  target = 'layouts/_partials/assets/section-title.html'
+[[module.mounts]]
+  source = '../../_vendor/github.com/gethinode/mod-utils/v6/layouts/_partials/utilities'
+  target = 'layouts/_partials/utilities'
+[[module.mounts]]
+  source = '../../data/structures/section-title.yml'
+  target = 'data/structures/section-title.yml'
+[[module.mounts]]
+  source = '../../_vendor/github.com/gethinode/mod-utils/v6/data/structures'
+  target = 'data/structures'

--- a/tests/templates/layouts/index.html
+++ b/tests/templates/layouts/index.html
@@ -156,3 +156,74 @@ FAIL in={{ index . 0 }}
 {{- end }}
 
 TOC FAILURES: {{ $tocFail }}
+
+{{- /*
+    Assertions for assets/section-title.html.
+
+    Each case renders the partial and compares the opening tag of the title element —
+    matched by its id attribute, which the surrounding wrapper div lacks. The harness
+    leaves site.Params.style unset, so every case builds on the partial's own defaults:
+    heading style "display", size 4, color "body".
+
+    The cases pin the level resolution (nil keeps the div, use-title maps onto level 1,
+    an explicit heading-level beats use-title, out-of-range falls back to the div), the
+    tag composition per level, and the class handling: a heading-level title receives the
+    margin reset — plus the weight and line-height reset under the "fs" heading style —
+    while a use-title title keeps the classes the h1 has always had, and a caller-supplied
+    heading-class always wins, including the empty string.
+*/ -}}
+{{- $stFail := 0 -}}
+{{- $stPage := site.GetPage "/blog/without-exact" -}}
+{{- $stCases := slice
+  (dict "case" "nil level keeps the div"
+        "args" (dict "heading" (dict "title" "Probe Nil"))
+        "want" `<div id="probe-nil" class="display-4 text-body pt-1">`)
+  (dict "case" "use-title maps onto level 1 with unchanged classes"
+        "args" (dict "heading" (dict "title" "Probe Legacy") "use-title" true)
+        "want" `<h1 id="probe-legacy" class="display-4 text-body pt-1">`)
+  (dict "case" "use-title with fs style keeps its weight and line height"
+        "args" (dict "heading" (dict "title" "Probe Legacy Fs") "use-title" true "heading-style" "fs")
+        "want" `<h1 id="probe-legacy-fs" class="fs-4 text-body pt-1">`)
+  (dict "case" "heading-level renders its tag with the margin reset"
+        "args" (dict "heading" (dict "title" "Probe Level Two") "heading-level" 2)
+        "want" `<h2 id="probe-level-two" class="display-4 text-body pt-1 mt-0 mb-0">`)
+  (dict "case" "heading-level six is the last valid level"
+        "args" (dict "heading" (dict "title" "Probe Level Six") "heading-level" 6)
+        "want" `<h6 id="probe-level-six" class="display-4 text-body pt-1 mt-0 mb-0">`)
+  (dict "case" "heading-level with fs style also resets weight and line height"
+        "args" (dict "heading" (dict "title" "Probe Level Fs") "heading-level" 2 "heading-style" "fs")
+        "want" `<h2 id="probe-level-fs" class="fs-4 text-body pt-1 mt-0 mb-0 fw-normal lh-base">`)
+  (dict "case" "explicit heading-level beats use-title"
+        "args" (dict "heading" (dict "title" "Probe Both") "heading-level" 3 "use-title" true)
+        "want" `<h3 id="probe-both" class="display-4 text-body pt-1 mt-0 mb-0">`)
+  (dict "case" "explicit level zero keeps the div"
+        "args" (dict "heading" (dict "title" "Probe Zero") "heading-level" 0)
+        "want" `<div id="probe-zero" class="display-4 text-body pt-1">`)
+  (dict "case" "level above six warns and falls back to the div"
+        "args" (dict "heading" (dict "title" "Probe Nine") "heading-level" 9)
+        "want" `<div id="probe-nine" class="display-4 text-body pt-1">`)
+  (dict "case" "negative level warns and falls back to the div"
+        "args" (dict "heading" (dict "title" "Probe Minus") "heading-level" -1)
+        "want" `<div id="probe-minus" class="display-4 text-body pt-1">`)
+  (dict "case" "empty heading-class leaves the element on its own styling"
+        "args" (dict "heading" (dict "title" "Probe Bare") "heading-level" 2 "heading-class" "")
+        "want" `<h2 id="probe-bare" class="display-4 text-body pt-1">`)
+  (dict "case" "heading-class replaces the reset"
+        "args" (dict "heading" (dict "title" "Probe Classy") "heading-level" 2 "heading-class" "my-4")
+        "want" `<h2 id="probe-classy" class="display-4 text-body pt-1 my-4">`)
+-}}
+{{- range $stCases -}}
+{{- $stGot := partial "assets/section-title.html" (merge (dict "page" $stPage) .args) -}}
+{{- $stEl := index (findRE `<(?:h[1-6]|div) id="[^>]*>` $stGot 1) 0 -}}
+{{- if eq $stEl .want }}
+PASS {{ .case }}
+{{- else }}
+FAIL {{ .case }}
+     want={{ .want }}
+     got ={{ $stEl }}
+{{- $stFail = add $stFail 1 -}}
+{{- errorf "section-title mismatch: case=%q want=%q got=%q" .case .want $stEl -}}
+{{- end -}}
+{{- end }}
+
+SECTION TITLE FAILURES: {{ $stFail }}


### PR DESCRIPTION
Phase 2 of #1519. Phase 1 (#2091) gave every template-rendered page an `h1` and listed seven
pages it could not reach. This handles those seven.

Companion pull request: **gethinode/mod-blocks#193**, "forward a heading level to section titles".

Neither repository changes what a page looks like on its own. This one adds the capability;
mod-blocks#193 is what asks for it, so the seven pages below only gain their headings once both
have landed and the module dependency is bumped. The two are safe to merge in either order —
without mod-blocks#193 nothing passes a level and every block keeps rendering a `<div>`, and
without this pull request mod-blocks passes an argument that the section title partial ignores.

## What is wrong today

A page assembled from content blocks has no headings at all. Not a missing `h1` — nothing. In
the example site that is the home page in all three languages, the team page in two, and the
two documentation landing pages: seven pages, zero headings between them.

Three things combine to cause it.

The template that renders a list page checks whether the page has content blocks. When it does,
it renders those blocks and stops; the page header, which carries the `h1`, is never reached.

The only thing that can produce a heading for a block is the shared section title partial. It
took a boolean called `use-title`, which defaults to off and, when switched on, could produce
only an `h1`.

Nothing switched it on. Twelve Bookshop wrappers render a section title and none of them passed
the boolean, so every block title on every site rendered as a `<div>`.

## Why a boolean cannot fix it

A page carries anywhere from one to a dozen section titles. Turning them all into headings with
a boolean would produce a dozen `h1` elements. The titles need a level, and something has to
decide what that level is.

That decision belongs to the page template, because it depends on the layout rather than on the
block. A list page renders blocks instead of a header, so its first block owns the `h1`. A
single page renders its header whenever it carries content, so its blocks must start at `h2`.

## The change

**A heading level replaces the boolean.** `assets/section-title.html` takes `heading-level`, an
integer from 1 to 6, where 0 keeps the `<div>`. `use-title` still maps onto level 1, so existing
callers behave exactly as before, and a caller that passes neither keeps the `<div>` this partial
has always rendered. Out-of-range values warn and fall back to a `<div>`.

Go's template engine rejects a dynamic element name, so the element is assembled as a string and
marked safe — the same approach `assets/toc-parse-content.html` already uses for its anchors.

**The page templates pass the level down.** `list.html` and `docs/all.html` render blocks in
place of the header, so their blocks start at 1. `single.html` renders its header whenever the
page carries content, so its blocks start at 2 in that case and at 1 otherwise.

**The level is an argument, not a running tally.** An earlier attempt handed the `h1` to
whichever title rendered first and tracked that on the page. It does not work, and the build says
so: Hugo decides for itself when a page's content is rendered, and the `example-bookshop`
shortcode composes live component previews while the content is being built — before the header
template runs. A documentation preview therefore took the page's `h1`, and the real page title
became a second one. Passing the level as an argument removes the ordering question entirely.

## Keeping the layout identical

`assets/scss/layouts/_type.scss` gives every heading a top margin, and Bootstrap adds a bottom
margin, a heavier weight and a tighter line height. A `<div>` has none of that, so promoting a
title in place would visibly push every hero down the page.

The partial resets those on a title promoted through `heading-level`, so it occupies the same
box the `<div>` did at every level. A `heading-class` argument replaces the reset — an empty
value means no extra classes — and a title that arrives through `use-title` keeps the styling
its `h1` has always had. The list page header is the one existing caller that already rendered
an `h1`; it passes the empty value and keeps its markup and spacing untouched.

## Verification

Every figure below comes from building hinode's example site with this branch and mod-blocks#193
resolved through a Hugo workspace, compared against a build of both repositories at their
unmodified state.

**Document structure.** A script over the built example site, run against both a pre-change and a
post-change build of all three languages. Before: 7 of 111 pages had no `h1`. After: every page
has exactly one `h1`, no page has two, and no page skips a level. Comparing the two heading
outlines page by page, exactly those 7 changed and the other 104 are identical.

**Rendered geometry.** Both builds were served locally and measured through Claude in Chrome at a
matched 1280×900 viewport. Every text-bearing element inside `<main>` was recorded with its
position, size, font size, weight, line height and margins. Across the nine pages that could
change — the seven promoted pages plus the two kinds of list page — **zero elements differ**, and
every page reports an identical scroll height. Screenshots of the home page before and after are
indistinguishable.

**Generated markup.** Comparing every built HTML file between the two builds: 95 of 122 files
are byte-identical, and the style sheet is unchanged, so no asset fingerprint moves. All 27 that
differ fall into three groups — the seven heading promotions, the list page titles whose element
is recomposed with identical attributes, and the generated argument tables on the documentation
pages gaining a `heading-level` row.

**Template tests.** Twelve assertions in `tests/templates` pin the partial's behaviour: nil
keeps the `<div>`, `use-title` maps onto level 1 with unchanged classes under both heading
styles, an explicit level beats `use-title`, out-of-range levels fall back to the `<div>`, each
level renders its tag, and `heading-class` replaces the reset — including the empty value, which
means no extra classes.

**Build health.** `pnpm lint` and `pnpm test` pass. The example site builds with no errors and no
new warnings. The theme also builds standalone, without mod-blocks.

## Notes

`404.html` and `tags/list.html` render no page content, so no section title can appear on them and
they are left alone.

Card titles remain a `<p>`. They are the other open item on the issue's checklist and need their
own change, because `assets/card.html` also backs the `card` shortcode, whose output lands in the
page content. The mobile table of contents scans that content for headings while the desktop one
reads the Markdown structure, and the scanner raises a build error for any heading without an id —
which cards do not have. Those two heading sources need to agree first.
