### PR TITLE
fix(button): separate custom attributes from role

### DIFF
--- a/layouts/_partials/assets/button.html
+++ b/layouts/_partials/assets/button.html
@@ -101,9 +101,7 @@
         {{- with $collapseID }} data-bs-toggle="collapse" aria-expanded="false" aria-controls="{{ . }}"{{ end -}}
         {{- if eq $state "active" }} data-bs-toggle="button" aria-pressed="true"{{ end -}}
         {{- if eq $state "inactive" }} data-bs-toggle="button" aria-pressed="false"{{ end -}}
-        {{- range $key, $val := $args.attributes -}}
-            {{ printf " %s=\"%s\"" $key $val | safeHTMLAttr }}
-        {{- end -}}
+        {{- range $key, $val := $args.attributes }} {{ printf "%s=%q" $key $val | safeHTMLAttr }}{{ end }}
         role="button"
         >
         <span class="d-flex justify-content-{{ $args.justify }}">


### PR DESCRIPTION
## Summary

`assets/button.html` rendered custom `attributes` glued to the `role`
attribute that follows them:

```html
<a href="/downloads/spec.json" class="btn btn-primary"
    download="spec.json"role="button">
```

The `range` block emitted each pair with a leading space inside the
`printf`, but its closing `{{- end -}}` trimmed the newline separating the
last attribute from `role="button"`. Browsers recover from the missing
separator, so the button still works, but the markup is invalid and any
consumer parsing the tag strictly sees a single mangled attribute.

## Fix

Switch to the one-line form already used in `assets/nav.html` and
`shortcodes/button-group.html`, which keeps the separator outside the
`printf` and leaves the trailing whitespace intact:

```gotemplate
{{- range $key, $val := $args.attributes }} {{ printf "%s=%q" $key $val | safeHTMLAttr }}{{ end }}
role="button"
```

`assets/button.html` was the only partial with this bug; `nav.html` and
`button-group.html` were already correct.

## Test plan

Verified against a live site (infusal.io) by patching its vendored copy of
the partial and rebuilding:

- A button with `attributes` `(dict "download" "odcs-json-schema-v3.0.1.json")`
  now renders `download="…"` and `role="button"` as separate attributes.
- Buttons without custom attributes render byte-identical output — the empty
  range emitted nothing before and after.
- `pnpm test` (lint + `test:templates`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)