### PR TITLE
fix(pagination): avoid inline partial name collision with Hugo

### DIFF
--- a/layouts/_partials/assets/pagination.html
+++ b/layouts/_partials/assets/pagination.html
@@ -14,7 +14,7 @@
     Copyright 2022 The Hugo Authors. Licensed under the Apache License, Version 2.0.
   */}}
 
-{{- define "_partials/inline/pagination/default" }}
+{{- define "_partials/inline/paginator/default" }}
   {{- $paginationFirst := partial "utilities/GetThemeIcon.html" (dict "id" "paginationFirst" "default" "fas angles-left") -}}
   {{- $paginationPrev := partial "utilities/GetThemeIcon.html" (dict "id" "paginationPrev" "default" "fas angle-left") -}}
   {{- $paginationNext := partial "utilities/GetThemeIcon.html" (dict "id" "paginationNext" "default" "fas angle-right") -}}
@@ -103,7 +103,7 @@
   {{- end }}
 {{- end -}}
 
-{{- define "_partials/inline/pagination/terse" }}
+{{- define "_partials/inline/paginator/terse" }}
   {{- $paginationFirst := partial "utilities/GetThemeIcon.html" (dict "id" "paginationFirst" "default" "fas angles-left") -}}
   {{- $paginationPrev := partial "utilities/GetThemeIcon.html" (dict "id" "paginationPrev" "default" "fas angle-left") -}}
   {{- $paginationNext := partial "utilities/GetThemeIcon.html" (dict "id" "paginationNext" "default" "fas angle-right") -}}
@@ -185,7 +185,7 @@
 {{- if and (not $args.err) (gt $args.page.Paginator.TotalPages 1) }}
   <nav aria-label="{{ T "paginationNav" }}">
     <ul class="pagination pagination-{{ $args.format }} justify-content-center">
-      {{- partial (printf "inline/pagination/%s" $args.format) $args.page }}
+      {{- partial (printf "inline/paginator/%s" $args.format) $args.page }}
     </ul>
   </nav>
 {{- end }}


### PR DESCRIPTION
Pagination nondeterministically renders Hugo's default markup instead of the theme's, which also strips the pagination icon rules out of the purged CSS. Three-line rename.

## The bug

`layouts/_partials/assets/pagination.html` defines its markup as inline partials named `_partials/inline/pagination/{default,terse}`. **Hugo ships an embedded template named `_partials/pagination.html`** — the names collide, and `partial "inline/pagination/default"` resolves to *Hugo's* embedded pagination template rather than ours on roughly 58% of builds.

When that happens the pagination renders as:

```html
<a aria-disabled="true" aria-label="First" class="page-link" role="button" tabindex="-1">
  <span aria-hidden="true">&laquo;&laquo;</span></a>
```

instead of:

```html
<a aria-disabled="true" aria-label="First page" class="page-link" role="button" tabindex="-1">
  <span aria-hidden="true"><svg class="svg-inline--fa bi bi-chevron-double-left" ...></span></a>
```

So the build silently loses **both** the themed icon and the translated `aria-label` (`T "paginationFirst"` → "First page" becomes a hardcoded "First").

## Knock-on effect on purged CSS

Because the icon classes never appear in the rendered HTML, they never reach `hugo_stats.json`, so PurgeCSS correctly strips the matching rules:

```css
.bi-chevron-double-left:before{content:"\f27f"}
.bi-chevron-double-right:before{content:"\f280"}
```

Net effect on a production site: the pagination first/last buttons ship **with no glyph at all** on a random ~58% of builds, and `main.min.css` changes hash between otherwise identical builds. That is how this was found — chasing a CSS hash that would not reproduce on gethinode.com.

## The fix

Rename the namespace to `_partials/inline/paginator/*`, which has no embedded counterpart. `sidebar/*` and `bundlev3/*` are the only other namespaced inline partials in the theme, and neither collides with Hugo's embedded set (`pagination`, `opengraph`, `twitter_cards`, `schema`, `disqus`, `google_analytics`).

## Verification

exampleSite, `HUGO_PAGINATION_PAGERSIZE=2`, checking `/nl/blog/` for Hugo's `&laquo;` markup:

| | degraded builds |
|---|---|
| before | **3 / 8** |
| after | **0 / 12** |

Independently on gethinode.com, which hits this on `/docs/configuration/`:

| | degraded builds |
|---|---|
| before | **21 / 36** |
| after | **0 / 16** |

With the fix, `main.min.css` is byte-identical across 6 consecutive builds there; before it alternated between two hashes.

Also run: `pnpm test` (eslint + stylelint + markdownlint + template tests) → 0 issues; `pnpm build:example` → 149 pages EN/FR/NL, exit 0.

## Ruled out

Recorded so nobody re-tests them: the dynamic `printf` partial name is not the cause (static `if`/`else` dispatch still degraded 7/10); there is no duplicate inline-partial definition; and `GOMAXPROCS=1` still degrades (2/6), so it is not simply a parallelism race. Shadowing the embedded template with a site-level `layouts/_partials/pagination.html` also suppresses it (14/14) but is a workaround, not a fix.

## Upstream

Hugo silently resolving a namespaced partial to an unrelated embedded template — nondeterministically, with no warning — looks like a Hugo defect in its own right, and is probably worth reporting separately. This PR is the theme-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)