### PR TITLE
refactor(components): reference the shared heading-level arguments

### DIFF
--- a/data/structures/section-title.yml
+++ b/data/structures/section-title.yml
@@ -13,23 +13,9 @@ arguments:
   size:
   use-title:
   heading-level:
-    type: int
-    optional: true
     release: v3.19.0
-    comment: >-
-      Heading level of the title, from 1 (h1) to 6 (h6). Defaults to 0, which
-      renders a div instead of a heading. Content blocks receive a level from
-      the page that renders them, so the first titled block of a page without a
-      page header becomes its h1.
   heading-class:
-    type: string
-    optional: true
     release: v3.19.0
-    comment: >-
-      Classes for the heading element, applied only when a heading level renders
-      one. Replaces the margin reset that otherwise keeps a title raised by
-      heading-level aligned with the div it succeeds; pass an empty string to
-      leave the element on its own styling.
   justify:
   link-type:
   use-section:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gethinode/mod-lottie/v3 v3.0.4 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.4 // indirect
 	github.com/gethinode/mod-simple-datatables/v4 v4.1.1 // indirect
-	github.com/gethinode/mod-utils/v6 v6.8.5 // indirect
+	github.com/gethinode/mod-utils/v6 v6.9.0 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/gethinode/mod-utils/v6 v6.8.4 h1:L8x3IcWEn2kms7WWuYwtbi/x7lIR18z+eJhU
 github.com/gethinode/mod-utils/v6 v6.8.4/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/gethinode/mod-utils/v6 v6.8.5 h1:hzJgNjw6NIORMvxeJ3Q6+qPaPzLc4CQtNTWRXFVjFPM=
 github.com/gethinode/mod-utils/v6 v6.8.5/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
+github.com/gethinode/mod-utils/v6 v6.9.0 h1:+7RsNAfYCaM3rAzwrkTC6Ui3vcpGYWj1Ek1CmUVcaq0=
+github.com/gethinode/mod-utils/v6 v6.9.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 h1:QDKcU3q39lFGzdVwM6kgCGnW3ibbMfYIi0Rwl62iJpo=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0/go.mod h1:5GdMfPAXzbA2gXBqTjC6l27kioSYzHlqDMh0+wyx7sU=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=


### PR DESCRIPTION
> **Draft — blocked on gethinode/mod-utils#361 being released and bumped here.** Until then `tests/templates` fails, by design; see below.

## What

Reduces `heading-level` and `heading-class` in `data/structures/section-title.yml` from full inline definitions to release-only overrides:

```yaml
  heading-level:
    release: v3.19.0
  heading-class:
    release: v3.19.0
```

## Why

Both shipped in v3.19.0 as complete inline definitions. They are common arguments, and common arguments are defined once in mod-utils `_arguments.yml` — `use-title`, the boolean `heading-level` replaces, has always been a single entry there. `ArgsSchema.html` merges the global definition with local overrides, so a key that only pins `release:` inherits type, optionality and comment. That is the prevailing shape: 98 arguments across these structure files already use it, `card-group.yml` alone accounting for twelve.

Keeping the definitions inline also duplicates them into every consumer — gethinode/mod-blocks#193 currently repeats the same six-line block fourteen times, which is the immediate motivation for fixing the source.

## Sequencing

1. gethinode/mod-utils#361 merges and releases
2. bump mod-utils here, then this merges
3. mod-blocks#193 drops its sidecar definitions in favour of blueprint keys

Against the currently vendored mod-utils v6.8.5 the schema has no type for either key, so `assets/section-title.html` reports `Invalid arguments` and the `section-title` assertions fail. That is the expected pre-release state, and it is exactly what the template tests added in #2116 are there to catch.

## Verification

Rendered against a local mod-utils carrying the two definitions, through a workspace `use`. All six argument shapes are byte-identical to shipped v3.19.0:

| args | rendered |
|---|---|
| unset | `<div id="a" class="display-4 text-body pt-1">` |
| `use-title: true` | `<h1 id="b" class="display-4 text-body pt-1">` |
| `heading-level: 2` | `<h2 id="c" class="display-4 text-body pt-1 mt-0 mb-0">` |
| `heading-level: 0` | `<div id="d" class="display-4 text-body pt-1">` |
| `heading-level: 1`, `heading-class: ""` | `<h1 id="e" class="display-4 text-body pt-1">` |
| `heading-level: 9` | warns, `<div id="f" class="display-4 text-body pt-1">` |

The unset row is the one that matters most: `_arguments.yml` deliberately sets no `default:`, so an omitted level stays nil and the legacy `use-title` fallback keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)