### PR TITLE
feat(a11y): adopt mod-blocks v2.4.0 so blocks carry heading levels

### DIFF
--- a/exampleSite/content/en/blocks-demo.md
+++ b/exampleSite/content/en/blocks-demo.md
@@ -1,0 +1,39 @@
+---
+title: Blocks Demo
+description: A single page that carries both content blocks and regular page content.
+showComments: false
+content_blocks:
+  - _bookshop_name: heading
+    heading:
+      title: A block on a page with content
+      content: >-
+        Blocks render above the page header, so on a page that also carries
+        content their titles are subsections and the page title below them
+        remains the only h1.
+  - _bookshop_name: cards
+    heading:
+      title: What the blocks look like
+    cols: 2
+    elements:
+      - title: Level from the page
+        icon: fas layer-group
+        content: >-
+          A page template hands its blocks a heading level. A list page renders
+          no header, so its first titled block opens the page. This page renders
+          a header, so its blocks start one level down.
+      - title: Level from the block
+        icon: fas sliders
+        content: >-
+          A block can set `heading_level` itself to pin a level, or `0` to keep
+          the plain division it rendered before heading levels existed.
+---
+
+## Regular page content
+
+Everything above this heading comes from `content_blocks` in the front matter.
+Everything from here down is ordinary Markdown, rendered through the page
+header and body.
+
+The page title is the `h1`. The two block titles above are `h2`, and this
+heading is an `h2` as well, so the page carries exactly one `h1` and skips no
+levels.

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -5,11 +5,11 @@ go 1.19
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20260715180930-14c65a3747d0 // indirect
 	github.com/cloudcannon/bookshop/hugo/v3 v3.19.0 // indirect
-	github.com/gethinode/mod-blocks/v2 v2.3.6 // indirect
+	github.com/gethinode/mod-blocks/v2 v2.4.0 // indirect
 	github.com/gethinode/mod-bootstrap-icons/v2 v2.0.2 // indirect
 	github.com/gethinode/mod-cookieyes/v3 v3.1.0 // indirect
 	github.com/gethinode/mod-docs v1.15.7 // indirect
 	github.com/gethinode/mod-fontawesome/v6 v6.1.4 // indirect
-	github.com/gethinode/mod-utils/v6 v6.8.5 // indirect
+	github.com/gethinode/mod-utils/v6 v6.9.0 // indirect
 	github.com/twbs/icons v1.13.1 // indirect
 )

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -4,6 +4,8 @@ github.com/cloudcannon/bookshop/hugo/v3 v3.19.0 h1:khb65FKbLXMWvm34OULEpKReCwNzE
 github.com/cloudcannon/bookshop/hugo/v3 v3.19.0/go.mod h1:s7mIonDhtsLcn10ZKuVXyqd6BDHI8vT1WQhZw8rPfY8=
 github.com/gethinode/mod-blocks/v2 v2.3.6 h1:xWvoWBfMXKTjsFuVh3sGZK80uQF1gl6gGt8w4GsZHiE=
 github.com/gethinode/mod-blocks/v2 v2.3.6/go.mod h1:/IfHiD5PCitH3IrpeMF/Pse/N+AbxkP8AYyIja8oJzk=
+github.com/gethinode/mod-blocks/v2 v2.4.0 h1:LjgEpU314lUPMpq63B/rWTUBzWTKTHDk1QSpPpADGJc=
+github.com/gethinode/mod-blocks/v2 v2.4.0/go.mod h1:bgbPL/PJzDFyvLcx7bd5uVJkkBDqFd0wZvA4DqqIdXs=
 github.com/gethinode/mod-bootstrap-icons/v2 v2.0.2 h1:KTQBwRB/1zRO3aS61bH2NNl/uTzelDLFxDjWbrqVKFc=
 github.com/gethinode/mod-bootstrap-icons/v2 v2.0.2/go.mod h1:oWYYQyAQgOFwrWwBZ8V+ztMCE7XmNTFbcmh28GWO2IA=
 github.com/gethinode/mod-cookieyes/v3 v3.1.0 h1:wan8yGs1bmwrgdySWSCqDbkiAsbTn8nWogwI+qKH6Is=
@@ -14,5 +16,7 @@ github.com/gethinode/mod-fontawesome/v6 v6.1.4 h1:6ppascnfF0Fy9csHLp2iVZVYhaguOO
 github.com/gethinode/mod-fontawesome/v6 v6.1.4/go.mod h1:VOzKLFEqI4O13IFZrKXOXFFHs26o8PgQtdv9fYUaxqA=
 github.com/gethinode/mod-utils/v6 v6.8.5 h1:hzJgNjw6NIORMvxeJ3Q6+qPaPzLc4CQtNTWRXFVjFPM=
 github.com/gethinode/mod-utils/v6 v6.8.5/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
+github.com/gethinode/mod-utils/v6 v6.9.0 h1:+7RsNAfYCaM3rAzwrkTC6Ui3vcpGYWj1Ek1CmUVcaq0=
+github.com/gethinode/mod-utils/v6 v6.9.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/twbs/icons v1.13.1 h1:6bmNXvoeIbvjFWjfbjXg5JGbelLD1haIsMaEIzE9UZI=
 github.com/twbs/icons v1.13.1/go.mod h1:GnRlymgVWp5iVJCMa0Me5b6tFyGpVc2bSxPMRGIJmyA=


### PR DESCRIPTION
Closes the loop on #1519 phase 2. gethinode/hinode#2116 taught the section title partial to render a heading, gethinode/mod-blocks#193 made the blocks ask for one, and #2122 moved the argument definitions into mod-utils. Until this bump none of it is visible: the example site still pinned mod-blocks v2.3.6, so nothing passed a level and every block title stayed a `div`.

## What changes

**Bumps the example site to mod-blocks v2.4.0** (and mod-utils to v6.9.0, pulled along with it).

Seven pages that rendered **no heading at all** — not a missing `h1`, nothing — now open with a real one:

| page | now |
|---|---|
| `/en/` | `<h1 id="welcome-to-hinode">` |
| `/nl/` | `<h1 id="welkom-bij-hinode">` |
| `/fr/` | `<h1 id="bienvenue-sur-hinode">` |
| `/en/team/` | `<h1 id="meet-our-team">` |
| `/fr/team/` | `<h1 id="rencontrez-notre-équipe">` |
| `/en/docs/` | `<h1 id="docs">` |
| `/en/docs/blocks/`, `/en/docs/components/` | `<h1 id="blocks">`, `<h1 id="components">` |

**Adds `blocks-demo`**, the fixture deferred from the mod-blocks review. It is the only page in the example site carrying both `content_blocks` and page content, which makes it the only cover for `single.html`'s level-2 branch — the one path the heading work had no fixture for. Its outline is exactly the documented shape:

```
h2  #a-block-on-a-page-with-content
h2  #what-the-blocks-look-like
h1  #blocks-demo
h2  #regular-page-content
```

Blocks render above the page header, so their titles are subsections and the page title below them stays the only `h1`. That ordering is the tradeoff recorded in `single.html`; this page makes it visible rather than theoretical.

It follows the existing `*-demo` convention (`form-demo`, `id-demo`, `lightbox-demo`, `table-demo`) and, like those, is not linked from any menu.

## Verification

- **112 pages, exactly one `h1` each, no page skips a level.** Previously seven had none.
- `hugo -s exampleSite` builds with no errors and no new warnings.
- `test:templates` exits 0; `markdownlint` clean on the new page.

## Still open

- gethinode/hinode#2121 — the lead scan can still lose the `h1` when every titled block sets `hide_empty` and the first is empty.
- `use-title` cannot be deprecated yet: mod-blocks still passes it from `assets/hero.html` and `assets/contact.html`.
- Consuming sites that use the CloudCannon editor will now see a `heading_level` field on every block, and can hide it the way gethinode.com already hides `bg-class`, `section-class` and `overlay-mode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)