### PR TITLE
feat(nav-item): add raw-body to pass an already-rendered body through

### DIFF
--- a/data/structures/nav-item.yml
+++ b/data/structures/nav-item.yml
@@ -27,6 +27,18 @@ arguments:
   raw:
     group: partial
     release: v1.3.0
+  raw-body:
+    type: bool
+    default: false
+    optional: true
+    group: shortcode
+    release: v3.21.0
+    comment: >-
+      Flag to pass the item's body through as already-rendered HTML instead of
+      running it through the page's markdown renderer. Set this when the body
+      is a nested shortcode that emits HTML of its own: on a site configured
+      with `markup.goldmark.renderer.unsafe = false`, that markup is otherwise
+      treated as raw HTML typed into markdown and is escaped or dropped.
   navitem-type:
     release: v1.0.0
   illustration:

--- a/layouts/_shortcodes/nav-item.html
+++ b/layouts/_shortcodes/nav-item.html
@@ -39,6 +39,15 @@
     {{- $itemID := printf "%s-btn-%d" $parent $id }}
     {{- $disabledID := cond $args.disabled $itemID "" }}
     {{- $body := trim .Inner " \r\n" -}}
+    {{/*
+        assets/nav-item.html resolves a pane body with `$args.body | $args.page.RenderString`,
+        which is right for prose but destroys a body that is already HTML — a nested shortcode's
+        output reaches RenderString indistinguishable from raw HTML typed into markdown, and a
+        site running goldmark with renderer.unsafe = false then escapes or drops it. The partial
+        already accepts a `raw` field that bypasses RenderString; raw-body wires it from the
+        shortcode. Empty when unset, so `or $args.raw (...)` keeps the original path.
+    */}}
+    {{- $raw := cond $args.rawBody $body "" -}}
     {{- $current := "" -}}
 
     {{/* Main code */}}
@@ -50,6 +59,7 @@
         "title"     $title
         "class"     $args.class
         "body"      $body
+        "raw"       $raw
         "show"      $args.show
         "disabled"  $args.disabled
         "_default"  $args.default
@@ -84,6 +94,7 @@
         "title"        $title
         "class"        $args.class
         "body"         $body
+        "raw"          $raw
         "show"         $args.show
         "disabled"     $args.disabled
         "navitem-type" "accordion"


### PR DESCRIPTION
## Problem

`assets/nav-item.html` resolves a pane body with `$args.body | $args.page.RenderString`. That is correct for prose or image bodies, but it destroys a body that is *already* HTML.

A `nav-item` whose body is a single nested shortcode reaches `RenderString` indistinguishable from raw HTML typed directly into markdown. On a site running goldmark with `renderer.unsafe = false` — which is Hinode's own default, and what `exampleSite` uses — CommonMark then comments the block out and renders the indented remainder as an escaped code block.

The partial already exposes a `raw` field that bypasses `RenderString` entirely (`assets/nav-item.html:75,87`), but nothing wires it from the shortcode call and no caller in the module sets it, so the field is unreachable from markdown.

## Change

Adds an opt-in `raw-body` boolean to the `nav-item` shortcode. When set, the already-resolved body is passed straight through as the partial's `raw`.

It is a **separate argument rather than exposing `raw` itself**, because the two carry different things: `raw` takes the resolved HTML, which cannot sensibly be supplied from a shortcode attribute, while `raw-body` is the flag that says "my body is already HTML". Overloading one name across the shortcode/partial boundary would put two types behind it.

Declared `type: bool`, `default: false`, `group: shortcode`, so `InitArgs` resolves it without the `| default` clobber that would break an explicit `false`.

## Backward compatibility

Defaults to `false`, so every existing call site is unaffected: the empty string it then passes leaves `or $args.raw (...)` on the original `RenderString` path. Both the tab-pane and accordion call sites are wired.

## Verification

Built `exampleSite` (which runs `renderer.unsafe = false`) with three panes:

| Pane | Output |
| --- | --- |
| Plain prose | `Just <strong>markdown</strong> prose` — existing path unchanged |
| Nested shortcode, no `raw-body` | `<!-- raw HTML omitted -->` plus an escaped `<pre><code>` block — the bug |
| Nested shortcode, `raw-body=true` | `<div class="d-flex alert alert-info" role="alert">` — renders correctly |

`npm test` passes (lint + template tests).

Note for anyone reproducing locally: a stale `_vendor` will fail `test:templates` with unrelated `section-title` schema errors — `pnpm mod:vendor` fixes it (mine was pinned at mod-utils v6.8.3 against a v6.9.0 requirement).

## Downstream

Found on a downstream site that renders a tabbed component whose panes each hold a single nested shortcode. It currently carries a full-file fork of this shortcode as an interim workaround; the fork is deleted once this ships.

