### PR TITLE
fix(sidebar): align icon-less labels and stop a root link stealing the highlight

### DIFF
--- a/assets/scss/components/_sidebar.scss
+++ b/assets/scss/components/_sidebar.scss
@@ -181,6 +181,38 @@ $sidebar-item-icon-column: calc(1.25em + #{$spacer * 0.25});
     }
 }
 
+// Hold the icon column open on rows that have no icon.
+//
+// A menu is free to mix the two - a "Home" entry among icon-bearing sections is
+// the common case - and the row without an icon then starts its label at the
+// padding edge while every neighbour starts one icon-width further right. The
+// labels no longer form a column, and the odd row reads as misplaced rather
+// than as merely unadorned.
+//
+// So such a row reserves the same column instead. `assets/sidebar.html` sets
+// the class on a row that has no icon in a list where something else does, so
+// the reservation follows the list it has to line up with: a list that uses no
+// icons at all is untouched, and neither is a nested list of its own.
+//
+// This is the width alone - no `text-indent` to go with it, unlike the hanging
+// indent above. There is no icon to pull the first line back past, and the
+// wrapped lines of a row whose text starts at the padding edge already line up
+// underneath it. Applies in both the collapsible and the plain sidebar, since
+// what it corrects is the resting layout the two share; in icon-only mode the
+// row has nothing left to show and the reserved column costs nothing.
+//
+// `!important` for the same reason the block above needs it: the base
+// `.sidebar-item` padding carries one.
+.sidebar-item.sidebar-item-icon-indent {
+    padding-left: calc(0.5rem + #{$sidebar-item-icon-column}) !important;
+}
+
+// Group headers again sit on the wrapper's padding, so they reserve the column
+// alone. They are not `.sidebar-item`, so this needs its own selector.
+.sidebar-item-group > div > a.sidebar-item-icon-indent {
+    padding-left: $sidebar-item-icon-column;
+}
+
 .btn-toggle-group {
     padding: 0.25rem 0.5rem;
     font-weight: 600;

--- a/layouts/_partials/assets/link.html
+++ b/layouts/_partials/assets/link.html
@@ -51,7 +51,20 @@
     {{- else -}}
         {{- $destination = (strings.TrimPrefix (strings.TrimSuffix "/" site.BaseURL) $destination) -}}
     {{- end -}}
-    {{- if not $destination }}{{ $destination = "/" }}{{ end -}}
+    {{/* A destination that normalizes away is the site root.
+
+        Stripping the base URL's path leaves nothing behind for a link to the site's own
+        home - "/" on a site rooted at "/", "/docs/" on one rooted at "/docs/" - and
+        `path.Clean` renders that empty string as ".". Both mean the same place, but only
+        the empty one is caught by an emptiness test: "." survives as a *relative* page
+        reference meaning "the page being rendered", so the lookup below resolves it to
+        the caller and the link quietly points at whatever page happened to render it.
+
+        The sidebar is where that surfaces: its markup is cached per section against the
+        section root, so a menu entry linking to "/" comes out as a link to the section
+        root, then matches the current page in the client-side active pass and takes the
+        highlight from the entry that owns it. */}}
+    {{- if or (not $destination) (eq $destination ".") }}{{ $destination = "/" }}{{ end -}}
 
     {{/* cue and tab carry no schema default, so an absent value is nil and an
          explicit false is a real choice. "default" treats false as empty and would

--- a/layouts/_partials/assets/sidebar.html
+++ b/layouts/_partials/assets/sidebar.html
@@ -79,11 +79,34 @@
     {{- $args = merge $args (dict "menu" $menu) -}}
 {{- end -}}
 
+{{/*
+    Does any entry in this list carry a leading icon?
+
+    Icons are per entry, but alignment is a property of the list: as soon as one row leads
+    with one, every other row's label in that list starts an icon-width further left and the
+    column of labels breaks. The rows that need to reserve that column are therefore the ones
+    without an icon in a list that has them, which only the list knows - hence a single
+    lookup per sibling list, passed down to the rows as `iconColumn`.
+
+    Scoped to the list rather than the whole sidebar on purpose: a nested list whose entries
+    are all icon-less is aligned already, and reserving a column there would indent it away
+    from the label it hangs under, changing every existing site that renders icons only on
+    its top level.
+*/ -}}
+{{- define "_partials/inline/sidebar/has-icons.html" -}}
+    {{- $found := false -}}
+    {{- range . -}}
+        {{- if .pre }}{{ $found = true }}{{ end -}}
+    {{- end -}}
+    {{- return $found -}}
+{{- end -}}
+
 {{- define "_partials/inline/sidebar/group-link.html" -}}
     {{- $page        := .page -}}
     {{- $group       := .group -}}
     {{- $baseURL     := .baseURL -}}
     {{- $pre         := $group.pre -}}
+    {{- $iconColumn  := .iconColumn | default false -}}
     {{- $collapsible := .collapsible | default false -}}
     {{- $href        := $group.link | default "" -}}
     {{- if and $href (not (hasPrefix $href "/")) -}}
@@ -92,8 +115,10 @@
     {{- if and $href (not (hasSuffix $href "/")) -}}{{- $href = printf "%s/" $href -}}{{- end -}}
     {{- $groupTitle := $group.title -}}
     {{- $groupTitle = partial "utilities/TitleCase.html" (dict "page" $page "text" $groupTitle) -}}
+    {{- $class := "sidebar-item text-decoration-none rounded w-100" -}}
+    {{- if and $iconColumn (not $pre) -}}{{- $class = printf "%s sidebar-item-icon-indent" $class -}}{{- end -}}
     <li class="mb-1">
-        <a class="sidebar-item text-decoration-none rounded w-100"
+        <a class="{{ $class }}"
            {{- if $collapsible }} data-sidebar-label="{{ $groupTitle }}"{{ end }}
            {{ with $href }}href="{{ . }}"{{ end }}>
             {{- with $pre -}}
@@ -120,7 +145,11 @@
     {{- $group := .group -}}
     {{- $data := .menu -}}
     {{- $pre := $group.pre -}}
+    {{- $iconColumn := .iconColumn | default false -}}
     {{- $filename := .filename -}}
+
+    {{- /* Resolved for this group's own children, who are a list of their own */ -}}
+    {{- $childIconColumn := partial "inline/sidebar/has-icons.html" $group.pages -}}
 
     {{- $doc_slug := partial "utilities/URLJoin.html" (dict "base" $baseURL "path" ($group.title | urlize)) -}}
     {{- $href := or $group.link $doc_slug -}}
@@ -146,7 +175,12 @@
                 {{ if not $ref }}
                     {{ $dest = "" }}
                 {{ end }}
-                <a {{ if gt $level 1 }}class="small" {{ end }}{{ with $dest }} href="{{ . }}"{{ else }}
+                {{- $headClass := "" -}}
+                {{- if gt $level 1 }}{{ $headClass = "small" }}{{ end -}}
+                {{- if and $iconColumn (not $pre) -}}
+                    {{- $headClass = trim (printf "%s sidebar-item-icon-indent" $headClass) " " -}}
+                {{- end -}}
+                <a {{ with $headClass }}class="{{ . }}" {{ end }}{{ with $dest }} href="{{ . }}"{{ else }}
                 data-bs-toggle="collapse"
                 data-bs-target="#sidebar-collapse-{{ $index }}-{{ $level }}"
                 {{ end }}>
@@ -183,14 +217,15 @@
                              nested collapse element IDs stay unique across
                              sibling branches at the same depth. */}}
                         {{ partial "inline/sidebar/group.html" (dict
-                            "page"     $page
-                            "index"    (printf "%v-%v" $index $childIndex)
-                            "level"    (add $level 1)
-                            "baseURL"  $href
-                            "group"    $item
-                            "menu"     $data
-                            "pre"      $item.pre
-                            "filename" $filename
+                            "page"       $page
+                            "index"      (printf "%v-%v" $index $childIndex)
+                            "level"      (add $level 1)
+                            "baseURL"    $href
+                            "group"      $item
+                            "menu"       $data
+                            "pre"        $item.pre
+                            "iconColumn" $childIconColumn
+                            "filename"   $filename
                             )
                         }}
                     {{- else -}}
@@ -202,6 +237,7 @@
                             "href"         $item.link
                             "menu"         $data
                             "pre"          $item.pre
+                            "iconColumn"   $childIconColumn
                             "filename"     $filename
                             )
                         }}
@@ -219,8 +255,10 @@
     {{- $title       := .title -}}
     {{- $data        := .menu -}}
     {{- $pre         := .pre -}}
+    {{- $iconColumn  := .iconColumn | default false -}}
     {{- $collapsible := .collapsible | default false -}}
     {{- $filename    := .filename -}}
+    {{- $iconIndent  := cond (and $iconColumn (not $pre)) " sidebar-item-icon-indent" "" -}}
     {{- $title = partial "utilities/TitleCase.html" (dict "page" $page "text" $title) -}}
     {{- $titleText   := $title -}}
     {{- if $collapsible -}}
@@ -253,7 +291,7 @@
         <li>
             <ul class="btn-toggle-nav list-unstyled pb-1">
                 <li>
-                    {{ $class := "sidebar-item text-decoration-none rounded w-100" }}
+                    {{ $class := printf "sidebar-item text-decoration-none rounded w-100%s" $iconIndent }}
                     {{ $link := partial "assets/link.html" (dict "href" $href "text" $itemText "class" $class "page" $page "exact" true "icon-mode" "svg") }}{{/* icon-mode "svg": same reason as the icon call sites - see the header comment. */}}
                     {{- if and $collapsible $title $link -}}
                         {{- $link = $link | replaceRE `(<a)\s` (printf `${1} data-sidebar-label="%s" ` ($title | htmlEscape)) -}}
@@ -268,7 +306,7 @@
         </li>
     {{ else }}
         <li>
-            {{ $class := "sidebar-item text-decoration-none rounded small w-100" }}
+            {{ $class := printf "sidebar-item text-decoration-none rounded small w-100%s" $iconIndent }}
             {{ $link := partial "assets/link.html" (dict "href" $href "text" $itemText "class" $class "page" $page "exact" true "icon-mode" "svg") }}{{/* icon-mode "svg": same reason as the icon call sites - see the header comment. */}}
             {{ if $link }}
                 {{ print $link | safeHTML }}
@@ -289,6 +327,7 @@
     {{- $iconSecondary := partial "utilities/GetThemeIcon.html" (dict "id" "sidebarSecondary" "default" "fas angle-up") -}}
     {{- $hasSpacerItem := gt (len (where $args.menu "spacer" true)) 0 -}}
     {{- $sidebarId     := $section | urlize | default "sidebar" -}}
+    {{- $iconColumn    := partial "inline/sidebar/has-icons.html" $args.menu -}}
     <nav class="sidebar flex-shrink-0 ps-1{{ if ge $levelMin 2 }} sidebar-sub{{ end }}{{ if $collapsible }} sidebar-collapsible{{ end }}{{ if $hasSpacerItem }} sidebar-has-spacer{{ end }}"
          data-sidebar-nav
          {{- if $collapsible }} data-storage-key="sidebar-collapsed"{{ end }}
@@ -354,6 +393,7 @@
                         "page"        $page
                         "group"       $item
                         "baseURL"     $baseURL
+                        "iconColumn"  $iconColumn
                         "collapsible" $collapsible
                     ) }}
                 {{- else -}}
@@ -365,6 +405,7 @@
                         "href"        $item.link
                         "menu"        $args.menu
                         "pre"         $item.pre
+                        "iconColumn"  $iconColumn
                         "collapsible" $collapsible
                         "filename"    $args.filename
                     ) }}
@@ -383,6 +424,7 @@
                                 "href"        .link
                                 "menu"        $args.menu
                                 "pre"         .pre
+                                "iconColumn"  $iconColumn
                                 "collapsible" $collapsible
                                 "filename"    $args.filename
                             ) }}
@@ -403,8 +445,10 @@
                     {{- if and $avHref (not (hasSuffix $avHref "/")) -}}{{- $avHref = printf "%s/" $avHref -}}{{- end -}}
                     {{- $avTitle := .title -}}
                     {{- $avTitle = partial "utilities/TitleCase.html" (dict "page" $page "text" $avTitle) -}}
+                    {{- $avClass := "sidebar-item text-decoration-none rounded flex-grow-1" -}}
+                    {{- if and $iconColumn (not .pre) -}}{{- $avClass = printf "%s sidebar-item-icon-indent" $avClass -}}{{- end -}}
                     <li class="d-flex align-items-center sidebar-secondary-row">
-                        <a class="sidebar-item text-decoration-none rounded flex-grow-1"
+                        <a class="{{ $avClass }}"
                            {{- if $collapsible }} data-sidebar-label="{{ $avTitle }}"{{ end }}
                            href="{{ $avHref }}">
                             {{- with .pre -}}
@@ -444,28 +488,33 @@
                 {{- end -}}
             {{- end -}}
             {{- with $activeGroup.pages -}}
+                {{- /* This mode renders the active group's children, not the L1 menu, so the
+                       icon column is resolved against that list */ -}}
+                {{- $subIconColumn := partial "inline/sidebar/has-icons.html" . -}}
                 <ul class="list-unstyled ps-0">
                 {{- range $index, $item := . -}}
                     {{- if $item.pages -}}
                         {{ partial "inline/sidebar/group.html" (dict
-                            "page"     $page
-                            "index"    $index
-                            "level"    1
-                            "baseURL"  $baseURL
-                            "group"    $item
-                            "menu"     $activeGroup.pages
-                            "filename" $args.filename
+                            "page"       $page
+                            "index"      $index
+                            "level"      1
+                            "baseURL"    $baseURL
+                            "group"      $item
+                            "menu"       $activeGroup.pages
+                            "iconColumn" $subIconColumn
+                            "filename"   $args.filename
                         ) }}
                     {{- else -}}
                         {{ partial "inline/sidebar/item.html" (dict
-                            "page"     $page
-                            "level"    $level
-                            "baseURL"  $baseURL
-                            "title"    $item.title
-                            "href"     $item.link
-                            "menu"     $activeGroup.pages
-                            "pre"      $item.pre
-                            "filename" $args.filename
+                            "page"       $page
+                            "level"      $level
+                            "baseURL"    $baseURL
+                            "title"      $item.title
+                            "href"       $item.link
+                            "menu"       $activeGroup.pages
+                            "pre"        $item.pre
+                            "iconColumn" $subIconColumn
+                            "filename"   $args.filename
                         ) }}
                     {{- end -}}
                 {{- end -}}
@@ -477,25 +526,27 @@
             {{- range $index, $item := $args.menu -}}
                 {{- if $item.pages }}
                     {{ partial "inline/sidebar/group.html" (dict
-                        "page"     $page
-                        "index"    $index
-                        "level"    (add $level 1)
-                        "baseURL"  $baseURL
-                        "group"    $item
-                        "menu"     $args.menu
-                        "filename" $args.filename
+                        "page"       $page
+                        "index"      $index
+                        "level"      (add $level 1)
+                        "baseURL"    $baseURL
+                        "group"      $item
+                        "menu"       $args.menu
+                        "iconColumn" $iconColumn
+                        "filename"   $args.filename
                         )
                     }}
                 {{- else }}
                     {{ partial "inline/sidebar/item.html" (dict
-                        "page"     $page
-                        "level"    $level
-                        "baseURL"  $baseURL
-                        "title"    $item.title
-                        "href"     $item.link
-                        "menu"     $args.menu
-                        "pre"      $item.pre
-                        "filename" $args.filename
+                        "page"       $page
+                        "level"      $level
+                        "baseURL"    $baseURL
+                        "title"      $item.title
+                        "href"       $item.link
+                        "menu"       $args.menu
+                        "pre"        $item.pre
+                        "iconColumn" $iconColumn
+                        "filename"   $args.filename
                         )
                     }}
                 {{- end }}

--- a/tests/templates/hugo.toml
+++ b/tests/templates/hugo.toml
@@ -65,3 +65,26 @@ disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
 [[module.mounts]]
   source = '../../data/structures/link.yml'
   target = 'data/structures/link.yml'
+
+# assets/sidebar.html renders real rows through assets/link.html and real icons through
+# mod-fontawesome, and both are what the assertions read, so neither is stubbed. The icon
+# module brings its own data (the structure it validates against plus the icon table), which
+# merges with the `data/structures` mounts above.
+[[module.mounts]]
+  source = '../../layouts/_partials/assets/sidebar.html'
+  target = 'layouts/_partials/assets/sidebar.html'
+[[module.mounts]]
+  source = '../../data/structures/sidebar.yml'
+  target = 'data/structures/sidebar.yml'
+[[module.mounts]]
+  source = '../../_vendor/github.com/gethinode/mod-fontawesome/v6/layouts/_partials/assets/icon.html'
+  target = 'layouts/_partials/assets/icon.html'
+[[module.mounts]]
+  source = '../../_vendor/github.com/gethinode/mod-fontawesome/v6/data'
+  target = 'data'
+# Where mod-fontawesome's own config mounts the icon set it resolves by name; without it
+# every icon renders as an error and the assertions could no longer tell an icon-bearing row
+# from an icon-less one.
+[[module.mounts]]
+  source = '../../_vendor/github.com/FortAwesome/Font-Awesome/svgs'
+  target = 'assets/svgs/fa'

--- a/tests/templates/hugo.toml
+++ b/tests/templates/hugo.toml
@@ -54,3 +54,14 @@ disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
 [[module.mounts]]
   source = '../../_vendor/github.com/gethinode/mod-utils/v6/data/structures'
   target = 'data/structures'
+
+# assets/link.html resolves its destination against the site and the calling page, so the
+# assertions need the real partial and its argument structure. Its icon call site is only
+# reached for external links with a cue, which none of the cases exercise, so no icon
+# partial is mounted.
+[[module.mounts]]
+  source = '../../layouts/_partials/assets/link.html'
+  target = 'layouts/_partials/assets/link.html'
+[[module.mounts]]
+  source = '../../data/structures/link.yml'
+  target = 'data/structures/link.yml'

--- a/tests/templates/layouts/index.html
+++ b/tests/templates/layouts/index.html
@@ -280,3 +280,111 @@ FAIL {{ .case }}
 {{- end }}
 
 LINK FAILURES: {{ $linkFail }}
+
+{{- /*
+    Assertions for the icon column in assets/sidebar.html.
+
+    A menu may mix rows that carry a leading icon with rows that do not, and the ones that do
+    not then start their label at the padding edge while their neighbours start an icon-width
+    further right. The renderer marks those rows with `sidebar-item-icon-indent`, which the
+    stylesheet turns into a reservation of the same column; these cases pin *which* rows get
+    marked, since nothing else in the build would notice if the answer changed.
+
+    The scope under test is the sibling list, not the sidebar: a row is marked only when
+    another row in its own list has an icon. That is what keeps a nested list of icon-less
+    entries - the common shape of a menu that puts icons on its top level only - sitting
+    under the label it belongs to instead of being pushed out by a column no row in it uses.
+
+    Each case renders the real partial and reduces the markup to one row per anchor, so a
+    case reads as the menu it describes: the title, whether that row carries an icon, and
+    whether it reserved the column. The menus are written as YAML because that is both the
+    shape a site authors them in and the only literal form that reaches the partial as the
+    `[]interface{}` its argument validator requires - Hugo's `slice` of dicts is typed
+    `[]map[string]interface{}` and is rejected before rendering starts.
+*/ -}}
+{{- $sbFail := 0 -}}
+{{- $sbPage := site.GetPage "/blog/without-exact" -}}
+{{- $sbCases := slice
+  (dict "case" "mixed list marks only the rows without an icon"
+        "menu" `
+- title: Home
+  link: /
+- title: With Exact
+  link: /blog/with-exact/
+  pre: fas house
+- title: Toc Override
+  link: /blog/toc-override/
+  pre: fas house`
+        "want" (slice "Home:noicon:indent" "With Exact:icon:plain" "Toc Override:icon:plain"))
+  (dict "case" "a list without icons is left alone"
+        "menu" `
+- title: Home
+  link: /
+- title: With Exact
+  link: /blog/with-exact/`
+        "want" (slice "Home:noicon:plain" "With Exact:noicon:plain"))
+  (dict "case" "a list where every row has an icon is left alone"
+        "menu" `
+- title: With Exact
+  link: /blog/with-exact/
+  pre: fas house
+- title: Toc Override
+  link: /blog/toc-override/
+  pre: fas house`
+        "want" (slice "With Exact:icon:plain" "Toc Override:icon:plain"))
+  (dict "case" "children are judged by their own list, not their parent's"
+        "menu" `
+- title: Home
+  link: /
+- title: Blog
+  link: /blog/
+  pre: fas house
+  pages:
+    - title: With Exact
+      link: /blog/with-exact/
+    - title: Toc Override
+      link: /blog/toc-override/`
+        "want" (slice "Home:noicon:indent" "Blog:icon:plain" "With Exact:noicon:plain" "Toc Override:noicon:plain"))
+  (dict "case" "a child list that mixes icons marks its own icon-less rows"
+        "menu" `
+- title: Blog
+  link: /blog/
+  pages:
+    - title: With Exact
+      link: /blog/with-exact/
+      pre: fas house
+    - title: Toc Override
+      link: /blog/toc-override/`
+        "want" (slice "Blog:noicon:plain" "With Exact:icon:plain" "Toc Override:noicon:indent"))
+-}}
+{{- range $sbCases -}}
+{{- $menu := .menu | transform.Unmarshal -}}
+{{- $html := partial "assets/sidebar.html" (dict "page" $sbPage "menu" $menu) -}}
+{{- $got := slice -}}
+{{- /* Go's regexp has no lookahead, so anchors are split off by hand: collapse the
+       markup's whitespace, cut it on the opening tag, and keep each piece up to its
+       closing tag. What is left of a piece before its first ">" is the tag's own
+       attributes, and what follows is the row's body. */ -}}
+{{- range (split (replaceRE `\s+` " " $html) "<a ") -}}
+    {{- if strings.Contains . "</a>" -}}
+        {{- $row := index (split . "</a>") 0 -}}
+        {{- $tag := index (split $row ">") 0 -}}
+        {{- $body := strings.TrimPrefix (printf "%s>" $tag) $row -}}
+        {{- $label := trim (replaceRE `&nbsp;` "" (replaceRE `<[^>]*>` "" $body)) " " -}}
+        {{- $icon := cond (strings.Contains $body "<svg") "icon" "noicon" -}}
+        {{- $indent := cond (strings.Contains $tag "sidebar-item-icon-indent") "indent" "plain" -}}
+        {{- $got = $got | append (printf "%s:%s:%s" $label $icon $indent) -}}
+    {{- end -}}
+{{- end -}}
+{{- if eq (delimit $got "|") (delimit .want "|") }}
+PASS {{ .case }}
+{{- else }}
+FAIL {{ .case }}
+     want={{ delimit .want "|" }}
+     got ={{ delimit $got "|" }}
+{{- $sbFail = add $sbFail 1 -}}
+{{- errorf "sidebar icon column mismatch: case=%q want=%q got=%q" .case (delimit .want "|") (delimit $got "|") -}}
+{{- end -}}
+{{- end }}
+
+SIDEBAR ICON COLUMN FAILURES: {{ $sbFail }}

--- a/tests/templates/layouts/index.html
+++ b/tests/templates/layouts/index.html
@@ -227,3 +227,56 @@ FAIL {{ .case }}
 {{- end }}
 
 SECTION TITLE FAILURES: {{ $stFail }}
+
+{{- /*
+    Assertions for assets/link.html.
+
+    Every case renders the partial from a page that is not the site home and compares the
+    emitted href, because the destination is normalized against both the site's base URL
+    and the calling page - and those two are what a link to the site root falls between.
+
+    The root case is the one with teeth. Normalization strips the base URL's path from the
+    destination, so on a site rooted at "/" the string "/" is left empty, and `path.Clean`
+    turns an empty path into ".". A "." is a valid relative page reference meaning *this
+    page*, so the lookup that follows resolves it to whichever page is rendering and the
+    link silently points at the caller instead of the home page. The sidebar makes that
+    visible: its markup is cached per section against the section root, so a menu entry
+    linking to "/" renders as a link to the section root, matches the current page in the
+    active-item pass, and steals the highlight from the entry that should own it.
+
+    The remaining cases hold the paths either side of it: a normal absolute link, a link
+    to a section, and an anchored one all still resolve to their own targets. The anchored
+    case keeps no trailing slash because the harness leaves main.internalLinks.pretty
+    unset, which is the partial's documented behaviour rather than an artefact.
+*/ -}}
+{{- $linkFail := 0 -}}
+{{- $linkPage := site.GetPage "/blog/without-exact" -}}
+{{- $linkCases := slice
+  (dict "case" "site root resolves to the site root, not the calling page"
+        "args" (dict "href" "/" "text" "Home")
+        "want" `href="/"`)
+  (dict "case" "absolute link to another page is left alone"
+        "args" (dict "href" "/blog/toc-override/" "text" "Toc")
+        "want" `href="/blog/toc-override/"`)
+  (dict "case" "absolute link to a section is left alone"
+        "args" (dict "href" "/blog/" "text" "Blog")
+        "want" `href="/blog/"`)
+  (dict "case" "anchor on an absolute link is preserved"
+        "args" (dict "href" "/blog/toc-override/#intro" "text" "Intro")
+        "want" `href="/blog/toc-override#intro"`)
+-}}
+{{- range $linkCases -}}
+{{- $linkGot := partial "assets/link.html" (merge (dict "page" $linkPage "exact" true) .args) -}}
+{{- $linkHref := index (findRE `href="[^"]*"` $linkGot 1) 0 -}}
+{{- if eq $linkHref .want }}
+PASS {{ .case }}
+{{- else }}
+FAIL {{ .case }}
+     want={{ .want }}
+     got ={{ $linkHref }}
+{{- $linkFail = add $linkFail 1 -}}
+{{- errorf "link mismatch: case=%q want=%q got=%q" .case .want $linkHref -}}
+{{- end -}}
+{{- end }}
+
+LINK FAILURES: {{ $linkFail }}


### PR DESCRIPTION
Two sidebar defects, reported against a downstream app whose menu mixes entries with and without icons and carries a `link: "/"` home entry.

## A link to the site root resolves to the calling page

`assets/link.html` normalizes its destination by stripping the base URL's path from it. For a link to the site's own home that leaves the empty string, and `path.Clean` renders the empty string as `"."`. Only the empty form was caught by the emptiness guard, so `"."` survived into the page lookup — where it is a valid *relative* reference meaning "the page being rendered".

The sidebar is what makes it visible. Its markup is cached per section against the section root, so a menu entry linking to `/` rendered as `href="/project/"` on the project section, `href="/monitor/"` on monitor, and so on. That entry then matched the current page exactly in `sidebar-active.js` — where the first exact match wins — and took the highlight from the entry that owns the page.

The guard now treats `"."` as the site root alongside the empty string.

## Entries without an icon do not line up with entries that have one

A row without an icon started its label at the padding edge while its neighbours started an icon-width further right, so the labels no longer formed a column and the odd row read as misplaced rather than as merely unadorned.

`assets/sidebar.html` now resolves, per sibling list, whether anything in that list carries an icon, and marks the rows that do not with `sidebar-item-icon-indent`; the stylesheet turns that into a reservation of the same column. The scope is the sibling list rather than the whole sidebar on purpose — a nested list of icon-less entries is aligned already, and reserving a column there would indent it away from the label it hangs under, which is the shape of every menu that puts icons on its top level only. The class is set by the template rather than derived in CSS with `:has()`, for the reason already documented for `sidebar-nav-icon-indent`.

Sites that render no icons, or icons on every row of a list, produce byte-identical markup.

## Tests

Adds assertions to the template test site for both: four `assets/link.html` cases (root, absolute, section, anchored) and five sidebar cases (mixed list, no icons, all icons, and nested lists in both directions). The harness gains mounts for `assets/link.html`, `assets/sidebar.html`, mod-fontawesome's `icon.html` and the icon set, so the rows and their icons are rendered for real rather than stubbed.

Reverting both fixes turns these into 5 failures; with them, `npm test` is clean and the theme's own site builds unchanged.

## Verification

Checked in a browser against a consuming app built with this branch:

- every label lands on the same x, in both the collapsible and the plain sidebar — in the plain one the hanging indent stays on the icon-bearing rows only, as intended
- the active item is correct on `/` (the home entry, exact), on a section root, and on an L2 page (L1 ancestor + L2 exact)
- collapsed icon-only mode is unchanged: identical row heights, icons on one centre line, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)