### PR TITLE
feat(table): collapse the filter button group into a dropdown on small screens

### DIFF
--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -35,11 +35,19 @@ document.querySelectorAll('.panel-dropdown').forEach(trigger => {
   })
 })
 
-document.querySelectorAll('.nav-panel .nav-link').forEach(trigger => {
-  trigger.addEventListener('click', event => {
-    const companion = event.srcElement.parentElement.parentElement.getAttribute('data-companion')
-    if (companion != null) {
-      updateDropdown(companion, trigger.getAttribute('id'), trigger.textContent.trim())
+// Keeps a companion dropdown in step with the control group it stands for, so the two never
+// disagree about which entry is active - which shows up when the viewport crosses the breakpoint
+// and the previously hidden control becomes the visible one.
+//
+// Delegated from the group itself and resolved with `closest`, so the depth of the control inside
+// the group does not matter: a nav nests its button in `button > li > ul`, a button group renders
+// `button > div`. Both carry `data-companion`, and both reach it the same way.
+document.querySelectorAll('[data-companion]').forEach(group => {
+  group.addEventListener('click', event => {
+    const trigger = event.target.closest('button[id]')
+    if (trigger == null || !group.contains(trigger)) {
+      return
     }
+    updateDropdown(group.getAttribute('data-companion'), trigger.getAttribute('id'), trigger.textContent.trim())
   })
 })

--- a/data/structures/table.yml
+++ b/data/structures/table.yml
@@ -29,6 +29,16 @@ arguments:
     release: v0.24.13
   filter:
   filter-col:
+  filter-responsive:
+    type: bool
+    default: false
+    optional: true
+    comment: >-
+      Whether the filter button group collapses into a dropdown below the site's
+      main breakpoint, for groups too wide to fit a narrow viewport. Defaults to
+      false, so the button group renders at every width. Requires `filter`, and
+      has no effect when the main breakpoint is `xs`.
+    release: v3.22.0
   justify:
     comment: >-
       Horizontal alignment of the filter controls. Requires `filter`, which is

--- a/exampleSite/content/en/table-demo.md
+++ b/exampleSite/content/en/table-demo.md
@@ -73,6 +73,23 @@ modules: ["simple-datatables"]
 | delta   | gadget | The fourth record, whose description runs on for a little while.   |
 {{< /table >}}
 
+## Responsive filter controls
+
+Below the main breakpoint the button group is replaced by a dropdown; at wider
+widths the group renders as usual. Enough categories to outgrow a narrow
+viewport, which is the case the argument exists for.
+
+{{< table filter="widget,gadget,doohickey,thingamajig,whatsit" filter-col="1" filter-responsive="true" sortable="true" class="fixture-filter-responsive" >}}
+
+| Name    | Type        | Description                                                        |
+|---------|-------------|--------------------------------------------------------------------|
+| alpha   | widget      | The first record, with a description long enough to need wrapping. |
+| bravo   | gadget      | The second record, also with a fairly long trailing description.   |
+| charlie | doohickey   | The third record. Short.                                           |
+| delta   | thingamajig | The fourth record, whose description runs on for a little while.   |
+| echo    | whatsit     | The fifth record, added to give every category a row.              |
+{{< /table >}}
+
 ## Table with caption
 
 {{< table caption="Overview of records" class="fixture-caption" >}}

--- a/layouts/_partials/assets/nav.html
+++ b/layouts/_partials/assets/nav.html
@@ -6,29 +6,6 @@
 
 {{- $error := false -}}
 
-{{- define "_partials/inline/nav-dropdown.html" -}}
-    {{ $id := .id }}
-    {{ $class := .class }}
-    {{ $titles := .titles }}
-    {{ $wrap := .wrap }}
-
-    <div id="dropdown-{{ $id }}" class="dropdown panel-dropdown {{ $class }}">
-    <button type="button" class="link-body-emphasis dropdown-toggle border-0 bg-transparent p-0" data-bs-toggle="dropdown" aria-expanded="false">
-        {{ cond (gt (len $titles) 0) (index $titles 0) (T "sectionMenu") }}
-    </button>
-        <ul class="dropdown-menu">
-            {{- range $index, $item := $titles -}}
-                {{ $itemID := printf "%s-btn-%d" $id $index -}}
-                {{- $show := eq $index 0 -}}
-                <li>
-                    <button class="dropdown-item {{ if not $wrap }} text-nowrap{{ end }}{{ if $show }} active{{ end }}"
-                    data-link="#{{ $id }}-btn-{{ $index }}" type="button">{{ $item }}</button>
-                </li>
-            {{ end }}
-        </ul>
-    </div>
-{{- end -}}
-
 {{/* Initialize arguments */}}
 {{- $args := partial "utilities/InitArgs.html" (dict "structure" "nav" "args" . "group" "partial") -}}
 {{- if or $args.err $args.warnmsg -}}
@@ -81,7 +58,7 @@
 
     {{/* Responsive dropdown (standard nav types only, controls-top position) */}}
     {{- if and $args.responsive (not $isBtnGroup) (ne $controlsPlacement "bottom") -}}
-        {{ partial "inline/nav-dropdown.html" (dict
+        {{ partial "assets/panel-dropdown.html" (dict
             "id"     $id
             "class"  (printf "d-%s-none py-%d" $breakpoint.current $padding.y)
             "titles" $titles
@@ -173,7 +150,7 @@
 
     {{/* Responsive dropdown (standard nav types only, controls-below position) */}}
     {{- if and $args.responsive (not $isBtnGroup) (eq $controlsPlacement "bottom") -}}
-        {{ partial "inline/nav-dropdown.html" (dict
+        {{ partial "assets/panel-dropdown.html" (dict
             "id"     $id
             "class"  (printf "d-%s-none py-%d" $breakpoint.current $padding.y)
             "titles" $titles

--- a/layouts/_partials/assets/nav.html
+++ b/layouts/_partials/assets/nav.html
@@ -39,6 +39,17 @@
 {{- $icons := $args.navIcons -}}
 {{- $itemAttrs := $args.navItemAttrs -}}
 
+{{/* The companion dropdown mirrors the nav, so it has to start on the same entry. `nav-show` names
+     that entry by item id rather than position, so resolve it to an index here - built from the same
+     `{args.id}-btn-{index}` expression the nav's own buttons use below, so the two cannot disagree.
+     Falls back to the first entry when `nav-show` is unset or names an item that does not exist. */}}
+{{- $active := 0 -}}
+{{- if $args.navShow -}}
+    {{- range $index, $item := $titles -}}
+        {{- if eq $args.navShow (printf "%s-btn-%d" $args.id $index) -}}{{- $active = $index -}}{{- end -}}
+    {{- end -}}
+{{- end -}}
+
 {{/* Tab-content class — spacing depends on type and controls-placement.
      tabs/callout: border acts as the visual separator, no margin needed.
      vertical:     left margin to offset from the vertical nav rail.
@@ -63,6 +74,7 @@
             "class"  (printf "d-%s-none py-%d" $breakpoint.current $padding.y)
             "titles" $titles
             "wrap"   $wrap
+            "active" $active
         ) }}
     {{- end -}}
 
@@ -155,6 +167,7 @@
             "class"  (printf "d-%s-none py-%d" $breakpoint.current $padding.y)
             "titles" $titles
             "wrap"   $wrap
+            "active" $active
         ) }}
     {{- end -}}
 

--- a/layouts/_partials/assets/panel-dropdown.html
+++ b/layouts/_partials/assets/panel-dropdown.html
@@ -1,0 +1,39 @@
+{{/*
+    Copyright © 2022 - 2026 The Hinode Team / Mark Dumay. All rights reserved.
+    Use of this source code is governed by The MIT License (MIT) that can be found in the LICENSE file.
+    Visit gethinode.com/license for more details.
+*/}}
+
+{{/* Renders a Bootstrap dropdown standing in for a group of buttons that is too wide to show at
+     narrow widths. Each item carries a `data-link` naming the button it represents; assets/js/nav.js
+     replays a click on that button, so the group keeps every behavior and this partial adds none of
+     its own. That is what lets one dropdown serve both a nav and a table filter.
+
+     The caller renders the real buttons with ids of the form `{id}-btn-{index}` in the same order as
+     `titles`, and hides them below its breakpoint while showing this dropdown there. The first entry
+     is treated as the initially active one and labels the toggle.
+
+     Extracted from assets/nav.html, where it was an inline partial. Every tag, class and attribute
+     is carried over unchanged - including the double space in `dropdown-item  text-nowrap`, kept so
+     the extraction reads as a move rather than a rewrite. Only the leading indentation of the
+     emitted HTML differs, because the markup no longer sits nested inside nav.html. */}}
+{{ $id := .id }}
+{{ $class := .class | default "" }}
+{{ $titles := .titles | default slice }}
+{{ $wrap := .wrap }}
+{{ $label := .label | default (T "sectionMenu") }}
+
+<div id="dropdown-{{ $id }}" class="dropdown panel-dropdown {{ $class }}">
+<button type="button" class="link-body-emphasis dropdown-toggle border-0 bg-transparent p-0" data-bs-toggle="dropdown" aria-expanded="false">
+    {{ cond (gt (len $titles) 0) (index $titles 0) $label }}
+</button>
+    <ul class="dropdown-menu">
+        {{- range $index, $item := $titles -}}
+            {{- $show := eq $index 0 -}}
+            <li>
+                <button class="dropdown-item {{ if not $wrap }} text-nowrap{{ end }}{{ if $show }} active{{ end }}"
+                data-link="#{{ $id }}-btn-{{ $index }}" type="button">{{ $item }}</button>
+            </li>
+        {{ end }}
+    </ul>
+</div>

--- a/layouts/_partials/assets/panel-dropdown.html
+++ b/layouts/_partials/assets/panel-dropdown.html
@@ -23,13 +23,20 @@
 {{ $wrap := .wrap }}
 {{ $label := .label | default (T "sectionMenu") }}
 
+{{/* Index of the entry the group starts on. A caller whose group does not start on its first entry
+     must say so, or the toggle would advertise an entry that is not the active one - which is what
+     `nav-show` used to produce before this argument existed. Both a missing argument and an explicit
+     `0` resolve to 0, so `default` is safe here; it is out of range only if a caller passes an index
+     its own `titles` does not hold. */}}
+{{ $active := .active | default 0 }}
+
 <div id="dropdown-{{ $id }}" class="dropdown panel-dropdown {{ $class }}">
 <button type="button" class="link-body-emphasis dropdown-toggle border-0 bg-transparent p-0" data-bs-toggle="dropdown" aria-expanded="false">
-    {{ cond (gt (len $titles) 0) (index $titles 0) $label }}
+    {{ cond (gt (len $titles) 0) (index $titles $active) $label }}
 </button>
     <ul class="dropdown-menu">
         {{- range $index, $item := $titles -}}
-            {{- $show := eq $index 0 -}}
+            {{- $show := eq $index $active -}}
             <li>
                 <button class="dropdown-item {{ if not $wrap }} text-nowrap{{ end }}{{ if $show }} active{{ end }}"
                 data-link="#{{ $id }}-btn-{{ $index }}" type="button">{{ $item }}</button>

--- a/layouts/_partials/assets/table.html
+++ b/layouts/_partials/assets/table.html
@@ -130,17 +130,42 @@
          which always spans the full width of its container. `justify` carries a default of
          `start` in mod-utils, preserving the original alignment for every existing caller. */}}
     {{ if $filter }}
+    {{/* `filter-responsive` swaps the button group for a dropdown below the main breakpoint, where a
+         group of more than a few buttons outgrows the viewport. Off by default, so an existing table
+         keeps its button group at every width. A no-op at `xs`, which has no Bootstrap display-utility
+         infix to hide the group with - the same guard `wrap` applies above.
+
+         The dropdown holds no behavior of its own: each item names a button through `data-link`, and
+         assets/js/nav.js replays the click on it, so filtering runs through the one handler either
+         way. That requires the buttons to carry ids of the form `{filterId}-btn-{index}` matching the
+         order of `$titles` below - "All" first, then the filter values. */}}
+    {{ $responsive := and $args.filterResponsive (ne $breakpoint "xs") }}
+    {{ $titles := slice (T "tableFilterAll" | default "All") }}
+    {{ range $filter }}{{ $titles = $titles | append (. | title) }}{{ end }}
     <div class="table-filter-controls d-flex justify-content-{{ $args.justify }} mb-3">
-        <div class="btn-group" role="group" aria-label="{{ T "tableFilterLabel" | default "Filter" }}">
+        {{ if $responsive }}
+        {{ partial "assets/panel-dropdown.html" (dict
+            "id"     $filterId
+            "class"  (printf "d-%s-none" $breakpoint)
+            "titles" $titles
+            "label"  (T "tableFilterLabel" | default "Filter")
+        ) }}
+        {{ end }}
+        <div class="btn-group{{ if $responsive }} d-none d-{{ $breakpoint }}-inline-flex{{ end }}"
+             role="group"
+             aria-label="{{ T "tableFilterLabel" | default "Filter" }}"
+             {{ if $responsive }}data-companion="dropdown-{{ $filterId }}"{{ end }}>
             <button type="button"
                     class="btn btn-outline-primary active"
+                    id="{{ $filterId }}-btn-0"
                     data-filter-table="{{ $filterId }}"
                     data-filter-value="">{{ T "tableFilterAll" | default "All" }}</button>
-            {{ range $filter }}
+            {{ range $index, $value := $filter }}
             <button type="button"
                     class="btn btn-outline-primary"
+                    id="{{ $filterId }}-btn-{{ add $index 1 }}"
                     data-filter-table="{{ $filterId }}"
-                    data-filter-value="{{ . }}">{{ . | title }}</button>
+                    data-filter-value="{{ $value }}">{{ $value | title }}</button>
             {{ end }}
         </div>
     </div>

--- a/layouts/_shortcodes/table.html
+++ b/layouts/_shortcodes/table.html
@@ -74,6 +74,7 @@
         "searchable"             $args.searchable
         "filter"                 $args.filter
         "filter-col"             $args.filterCol
+        "filter-responsive"      $args.filterResponsive
         "justify"                $args.justify
         "wrap"                   $args.wrap
         "wrapper"                $args.wrapper


### PR DESCRIPTION
## Summary

Adds `filter-responsive` to the `table` shortcode: below the site's main breakpoint the filter button group is replaced by a dropdown, for groups with more categories than a narrow viewport can hold.

Off by default, so every existing filtered table renders its button group at all widths, exactly as before.

## Why

A filter group of more than a few categories overflows its row on a phone. The nav component already solves this shape with a companion dropdown, so this reuses that mechanism rather than inventing a second one.

## How it works

The dropdown carries no behavior of its own. Each item names a filter button through `data-link`, and `nav.js` replays the click on it — so filtering still runs through the single existing handler and keeps composing with sorting, paging and search. No new filter JavaScript.

Three supporting changes:

- **`assets/panel-dropdown.html`** — `nav.html`'s inline `nav-dropdown` extracted into a shared partial so both callers use it. Every tag, class and attribute is carried over unchanged (including the double space in `dropdown-item  text-nowrap`, kept so the extraction reads as a move rather than a rewrite). Only the emitted indentation differs, since the markup no longer sits nested inside `nav.html` — verified by diffing a full example-site build against `main`.
- **`nav.js`** — the companion sync now delegates from the `[data-companion]` group and resolves the control with `closest`, instead of assuming a nav's `button > li > ul` nesting. A nav and a button group both reach their dropdown, so neither strands a stale label when the viewport crosses the breakpoint.
- **`_shortcodes/table.html`** — forwards the new argument, which the shortcode's explicit allowlist would otherwise drop.

`filter-responsive` is defined inline in `data/structures/table.yml` rather than in `mod-utils`, so this needs no module release. Note the global `responsive` argument was **not** reused: it defaults to `true`, which would have flipped every existing table into dropdown mode, and `table.yml` already uses "responsive" to describe the horizontal-scroll wrapper.

A no-op at `xs`, which has no Bootstrap display-utility infix to hide the group with — the same guard `wrap` already applies.

## Bug fix included

`fix(nav): start the companion dropdown on the nav's own active entry`

`panel-dropdown` hardcoded the first entry as active, so a nav using `nav-show` to open on a later tab advertised the wrong one — the toggle read "Tab 1" while Tab 3 was the tab actually showing. Selecting a tab corrected it, so the mismatch only showed on first paint, which is when a reader looks at it.

Pre-existing; the extraction only made it easy to see. `nav-show` names its entry by item id, so `nav.html` resolves it to an index using the same `{args.id}-btn-{index}` expression its own buttons use, and passes it as `active`.

## Testing

New fixture in `exampleSite/content/en/table-demo.md` (`fixture-filter-responsive`), with enough categories to overflow a narrow viewport.

Driven in a browser at 390px and 1200px:

- Dropdown item → `data-link` → real button → table filters. Rows went `[widget, gadget, doohickey, thingamajig, whatsit]` → `[doohickey]`; the real button took `active` and the toggle relabeled.
- At 1200px, clicking a real button updated the hidden dropdown's label and active item, so crossing the breakpoint doesn't strand a stale label.
- The three pre-existing filter fixtures render a plain `btn-group` with no companion and no dropdown at 390px — default behavior unchanged.
- Nav regression: forward (dropdown → tab + pane switch) and reverse (tab button → dropdown label) both still work.
- The `nav-show` fixture's dropdown now renders "Tab 3", matching its active tab.

`pnpm lint` clean, `pnpm test:templates` passes, example site builds clean.

## Follow-ups (not in this PR)

- `mod-blocks`' `list` component forwards `filter` / `filter_col` / `wrap` but not `filter-responsive`, so component-rendered tables can't opt in until it does.
- Docs live in gethinode/mod-docs — see the companion PR. **That PR should not merge before this ships in v3.22.0**, or its example would pass an argument the theme doesn't know and raise an "Invalid arguments" warning.
