### PR TITLE
feat(table): fold a record into column groups on small devices

### DIFF
--- a/assets/scss/components/_table.scss
+++ b/assets/scss/components/_table.scss
@@ -26,6 +26,44 @@
     }
 }
 
+// A folded group holds the values of several columns in one cell, with their headings hidden. They
+// are laid out rather than concatenated: the cells are merged verbatim, so without this the values
+// would run together into one string ("DatabaselaunchShipped").
+//
+// Equal, left-aligned columns, so values line up down the table instead of drifting with their own
+// widths - the alignment the hidden headings would otherwise have provided.
+//
+// The column count adapts rather than matching the folded column count. Four equal tracks across a
+// 390px viewport are ~74px each, which is narrower than a label like "Warehouse" - and a rendered
+// badge is wider than its bare text - so a fixed count breaks values mid-word. `auto-fit` keeps the
+// tracks equal and drops to as many as fit, laying four values out 2x2 on a phone and 4-across when
+// there is room. `min(100%, 7rem)` keeps a single-value group (a description) full width instead of
+// forcing a 7rem minimum on a viewport narrower than that.
+//
+// This sits on a wrapper inside the cell, never on the cell itself: a `display` of grid or flex
+// takes a `td` out of the table formatting context and `colspan` stops applying with it, leaving
+// the folded row's stripe and border cut off part way across the table.
+.table-wrap-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 7rem), 1fr));
+
+    // Values fill their track rather than being sized to content, so the column's own alignment
+    // still decides where the value sits. Left is simply what `text-align` already resolves to, so
+    // an unaligned table reads left-aligned without that being hard-coded here - and a column the
+    // author centred or right-aligned keeps that after folding.
+    place-items: center stretch;
+    gap: 0.25rem 0.5rem;
+}
+
+// A value wider than its track would otherwise spill into the next one and collide with it
+// ("Warehouseplateau-1"). `min-width: 0` lets the track shrink below its content so the value wraps
+// inside its own column instead; `anywhere` because these are single words often enough that
+// `break-word` alone would leave the overflow in place.
+.table-wrap-value {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
 @include media-breakpoint-down(#{$main-breakpoint}) {
     // Below the breakpoint the data row and the row holding the wrapped column must read as a
     // single record, so the data row drops its bottom border.
@@ -37,6 +75,30 @@
     .table-wrap.table-striped > tbody > tr:nth-of-type(4n + 2) > * {
         --bs-table-color-type: var(--bs-table-striped-color);
         --bs-table-bg-type: var(--bs-table-striped-bg);
+    }
+
+    // `wrap-cols` renders a record across more than two rows, which moves the stripe. The pattern
+    // alternates per record, so a record of $rows rows has a period of 2 * $rows and the striped
+    // record occupies the first $rows of it. `nth-of-type` accepts no custom property, so the rule
+    // is emitted per row count rather than parameterised. These rules live inside the query because
+    // wrapping only applies below the breakpoint - above it the record is one row and Bootstrap's
+    // own striping is correct. Two rows keeps the pair of rules above; the loop starts at three.
+    @each $rows in (3, 4, 5, 6) {
+        $period: $rows * 2;
+
+        @for $i from 1 through $rows {
+            .table-wrap-#{$rows}.table-striped > tbody > tr:nth-of-type(#{$period}n + #{$i}) > * {
+                --bs-table-color-type: var(--bs-table-striped-color);
+                --bs-table-bg-type: var(--bs-table-striped-bg);
+            }
+        }
+
+        @for $i from ($rows + 1) through $period {
+            .table-wrap-#{$rows}.table-striped > tbody > tr:nth-of-type(#{$period}n + #{$i}) > * {
+                --bs-table-color-type: initial;
+                --bs-table-bg-type: initial;
+            }
+        }
     }
 }
 

--- a/data/structures/table.yml
+++ b/data/structures/table.yml
@@ -46,6 +46,16 @@ arguments:
       the full width of its container.
     release: v3.18.0
   wrap:
+  wrap-cols:
+    type: string
+    optional: true
+    comment: >-
+      Comma-separated column count per rendered row when wrapping, summing to the
+      table's column count. Splits a record across more than two rows on small
+      devices, for example "2,4,1". Only the first group keeps one cell per
+      column; later groups collapse into a single spanning cell. Requires `wrap`;
+      an invalid list falls back to wrapping the last column only.
+    release: v3.23.0
   wrapper:
     release: v2.0.0
   caption:

--- a/exampleSite/content/en/table-demo.md
+++ b/exampleSite/content/en/table-demo.md
@@ -109,3 +109,55 @@ viewport, which is the case the argument exists for.
 | alpha | widget | The first record.  |
 | bravo | gadget | The second record. |
 {{< /table >}}
+
+## Wrapped into column groups
+
+Splits each record across three rows below the breakpoint: `#` and Name stay on
+the lead row, the four badges fold onto a row of their own, and the description
+takes the last. Mirrors a catalog table's shape.
+
+{{< table wrap="true" wrap-cols="2,4,1" sortable="true" paginate="true" pagination="4" class="table-striped fixture-wrap-cols" >}}
+
+| #  | Name    | Category  | Plateau   | Status   | Role   | Description                                                        |
+|----|---------|-----------|-----------|----------|--------|--------------------------------------------------------------------|
+| 11 | alpha   | Database  | launch    | Shipped  | both   | The first record, with a description long enough to need wrapping. |
+| 12 | bravo   | Warehouse | plateau-1 | Planned  | target | The second record, also with a fairly long trailing description.   |
+| 13 | charlie | File      | launch    | Shipped  | source | The third record. Short.                                           |
+| 14 | delta   | Streaming | plateau-2 | Planned  | source | The fourth record, whose description runs on for a little while.   |
+| 15 | echo    | API       | plateau-3 | Planned  | both   | The fifth record, added so the stripe pattern is visible.          |
+| 16 | foxtrot | Database  | launch    | Shipped  | target | The sixth record, closing out the sample set.                      |
+{{< /table >}}
+
+## Column groups without a data table
+
+The same split on a plain table, which folds server-side with display utilities
+rather than in the browser. No sorting, paging or searching, so no data table.
+
+{{< table wrap="true" wrap-cols="2,4,1" class="table-striped fixture-wrap-cols-plain" >}}
+
+| #  | Name    | Category  | Plateau   | Status   | Role   | Description                                                        |
+|----|---------|-----------|-----------|----------|--------|--------------------------------------------------------------------|
+| 21 | golf    | Database  | launch    | Shipped  | both   | A plain-table record, with a description long enough to wrap.      |
+| 22 | hotel   | Warehouse | plateau-1 | Planned  | target | A second plain-table record, also with a trailing description.     |
+{{< /table >}}
+
+## Column groups that no longer match
+
+Both tables ask for `2,4` across seven columns — the shape a group list is left
+in when a column is added and the list is not updated. The list is refused and
+the table falls back to wrapping the last column only, rather than folding on
+stale boundaries. The first is a data table, the second a plain one.
+
+{{< table wrap="true" wrap-cols="2,4" sortable="true" class="fixture-wrap-cols-stale" >}}
+
+| #  | Name  | Category | Plateau | Status  | Role | Description                          |
+|----|-------|----------|---------|---------|------|--------------------------------------|
+| 31 | india | Database | launch  | Shipped | both | A record whose group list is stale.  |
+{{< /table >}}
+
+{{< table wrap="true" wrap-cols="2,4" class="fixture-wrap-cols-stale-plain" >}}
+
+| #  | Name   | Category | Plateau | Status  | Role | Description                          |
+|----|--------|----------|---------|---------|------|--------------------------------------|
+| 32 | juliet | Database | launch  | Shipped | both | A record whose group list is stale.  |
+{{< /table >}}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gethinode/mod-leaflet/v3 v3.1.3 // indirect
 	github.com/gethinode/mod-lottie/v3 v3.0.4 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.4 // indirect
-	github.com/gethinode/mod-simple-datatables/v4 v4.1.1 // indirect
+	github.com/gethinode/mod-simple-datatables/v4 v4.2.0 // indirect
 	github.com/gethinode/mod-utils/v6 v6.9.0 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/gethinode/mod-simple-datatables/v4 v4.1.0 h1:AtEtLH9RoAEIpElg0k6UkVlH
 github.com/gethinode/mod-simple-datatables/v4 v4.1.0/go.mod h1:jRHoX20bUiaVg7UtKzMjfHQjd5M6WZ8hAeVqA3TKwTA=
 github.com/gethinode/mod-simple-datatables/v4 v4.1.1 h1:Bidf8FA9SxBBb163D0yteTyad/sNiVK31IdqbcF/tZs=
 github.com/gethinode/mod-simple-datatables/v4 v4.1.1/go.mod h1:irmXKx2jeppfpGRsCC91vN8dA4U2nQfy2eW8bajUeJo=
+github.com/gethinode/mod-simple-datatables/v4 v4.2.0 h1:n1GyPqVQ6o44awWIAiAwg/xZ6LYYQZuTQk6CuagboeI=
+github.com/gethinode/mod-simple-datatables/v4 v4.2.0/go.mod h1:bIYh9MBNdBe5vzSfmymqVzdVh+RSA7yPbMfnIayg8eo=
 github.com/gethinode/mod-utils/v6 v6.7.0 h1:DxqKUb13/6ydcntGIrUj1YD892VwarB8zGj+77CeUwM=
 github.com/gethinode/mod-utils/v6 v6.7.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/gethinode/mod-utils/v6 v6.8.0 h1:Rz/6DlPKVW0791jSsobxx4I4pKQ38H4JOEeOV+GeRzU=

--- a/layouts/_markup/render-table.html
+++ b/layouts/_markup/render-table.html
@@ -22,6 +22,28 @@
 {{ $given := split (or $attr.class "") " " }}
 {{ $wrap := and (in $given "table-wrap") (not $dataTable) (ne $breakpoint "xs") (gt $cols 1) }}
 
+{{/* `wrap-cols` splits a record across more than two rows: a column count per rendered row, summing
+     to the column count. Refused unless every entry is a positive integer and the total matches, so
+     a stale list left behind after a column was added or removed folds on the old boundaries rather
+     than dropping or duplicating a column - it falls back to the default split instead.
+     `int` yields 0 for anything non-numeric, which the positive test then rejects. */}}
+{{ $groups := slice (sub $cols 1) 1 }}
+{{ with and $wrap (.Page.Store.Get "hinodeTableWrapCols") }}
+    {{ $parsed := slice }}
+    {{ $valid := true }}
+    {{ range split . "," }}
+        {{ $n := int (trim . " ") }}
+        {{ if lt $n 1 }}{{ $valid = false }}{{ end }}
+        {{ $parsed = $parsed | append $n }}
+    {{ end }}
+    {{ $sum := 0 }}
+    {{ range $parsed }}{{ $sum = add $sum . }}{{ end }}
+    {{ if and $valid (eq $sum $cols) (gt (len $parsed) 1) }}
+        {{ $groups = $parsed }}
+    {{ end }}
+{{ end }}
+{{ $lead := index $groups 0 }}
+
 {{/* Rebuild the class list: drop empties, drop `table-wrap` when it does not apply, and ensure
      `table` is present so Bootstrap styles the element. */}}
 {{ $classes := slice }}
@@ -29,6 +51,12 @@
     {{ if and (ne . "") (or $wrap (ne . "table-wrap")) }}
         {{ $classes = $classes | append . }}
     {{ end }}
+{{ end }}
+{{/* The rows-per-record keys the striping rules, which recompute Bootstrap's alternation over a
+     record rather than a row. Only emitted past the default two, which the plain `table-wrap`
+     selector already covers. */}}
+{{ if and $wrap (gt (len $groups) 2) }}
+    {{ $classes = $classes | append (printf "table-wrap-%d" (len $groups)) }}
 {{ end }}
 {{ if not (in $classes "table") }}{{ $classes = $classes | append "table" }}{{ end }}
 {{ $attr = merge $attr (dict "class" (delimit ($classes | uniq) " ")) }}
@@ -62,7 +90,7 @@
           {{- with $cell.Alignment }}
             {{- $cellClasses = $cellClasses | append (printf "text-%s" (index $align .)) }}
           {{- end }}
-          {{- if and $wrap (eq $i (sub $length 1)) }}
+          {{- if and $wrap (ge $i $lead) }}
             {{- $cellClasses = $cellClasses | append "d-none" (printf "d-%s-table-cell" $breakpoint) }}
           {{- end }}
           <th{{ with $cellClasses }} class="{{ delimit . " " }}"{{ end }}>
@@ -75,6 +103,9 @@
   <tbody>
     {{- range .TBody }}
       {{- $length := len . }}
+      {{- /* The folded rows below read cells by position from inside a nested range, where neither
+             `.` nor `$` is this row any more - `$` is the render hook's own context. Hold the row. */}}
+      {{- $row := . }}
       <tr>
         {{- range $i, $cell := . }}
           {{- $cellClasses := slice }}
@@ -82,7 +113,7 @@
             {{- $cellClasses = $cellClasses | append (printf "text-%s" (index $align .)) }}
           {{- end }}
           {{- if $wrap }}
-            {{- if eq $i (sub $length 1) }}
+            {{- if ge $i $lead }}
               {{- $cellClasses = $cellClasses | append "d-none" (printf "d-%s-table-cell" $breakpoint) }}
             {{- else }}
               {{- $cellClasses = $cellClasses | append "table-border-bottom-wrap" }}
@@ -94,12 +125,27 @@
         {{- end }}
       </tr>
       {{- if $wrap }}
-        {{- $last := index . (sub $length 1) }}
-        <tr class="d-{{ $breakpoint }}-none">
-          <td colspan="{{ sub $length 1 }}"{{ with $last.Alignment }} class="text-{{ index $align . }}"{{ end }}>
-            {{- $last.Text -}}
-          </td>
-        </tr>
+        {{- /* One row per folded group, each spanning the columns the lead row leaves visible. The
+               row is hidden above the breakpoint, where the record renders as a single row instead.
+               `colspan` counts the lead group rather than every column: the folded headings are
+               display:none there and contribute no column, so spanning the full count would reach
+               past the grid and cut the row's stripe and border off part way across. */}}
+        {{- $offset := $lead }}
+        {{- range $g, $size := (after 1 $groups) }}
+          <tr class="d-{{ $breakpoint }}-none">
+            <td colspan="{{ $lead }}"{{ if lt (add $g 2) (len $groups) }} class="table-border-bottom-wrap"{{ end }}>
+              <div class="table-wrap-group">
+                {{- range $j := (seq $size) }}
+                  {{- $cell := index $row (add $offset (sub $j 1)) }}
+                  <span class="table-wrap-value{{ with $cell.Alignment }} text-{{ index $align . }}{{ end }}">
+                    {{- $cell.Text -}}
+                  </span>
+                {{- end }}
+              </div>
+            </td>
+          </tr>
+          {{- $offset = add $offset $size }}
+        {{- end }}
       {{- end }}
     {{- end }}
   </tbody>

--- a/layouts/_partials/assets/table.html
+++ b/layouts/_partials/assets/table.html
@@ -79,6 +79,15 @@
      needs no JavaScript. */}}
 {{ if and $wrap $dataTable }}
     {{ $attributes = printf "%s data-table-wrap=true data-table-wrap-breakpoint=%s" $attributes $breakpoint }}
+    {{/* `wrap-cols` splits the record across more than two rows: a comma-separated column count per
+         rendered row, summing to the table's column count. Only the first group keeps one cell per
+         column, so it alone drives the column grid; later groups collapse into a single spanning
+         cell. Passed through verbatim - the column count lives in the rendered header, which only
+         the browser has, so the group list is validated there and an invalid one falls back to the
+         default two-row split. */}}
+    {{ with $args.wrapCols }}
+        {{ $attributes = printf "%s data-table-wrap-cols=%s" $attributes . }}
+    {{ end }}
 {{ end }}
 
 {{/* Filter */}}
@@ -109,14 +118,20 @@
     {{ $caption := "" }}
     {{ with $args.caption }}{{ $caption = . | $args.page.RenderString }}{{ end }}
 
+    {{/* `wrap-cols` reaches the render hook the same way, since a plain table folds server-side and
+         only the hook sees the parsed rows. A data table ignores it here and folds in the browser
+         instead, so the value is passed either way and the hook decides. */}}
     {{ $store := $args.page.Store }}
     {{ $outer := $store.Get "hinodeTableIsDataTable" }}
     {{ $outerCaption := $store.Get "hinodeTableCaption" }}
+    {{ $outerWrapCols := $store.Get "hinodeTableWrapCols" }}
     {{ $store.Set "hinodeTableIsDataTable" $dataTable }}
     {{ $store.Set "hinodeTableCaption" $caption }}
+    {{ $store.Set "hinodeTableWrapCols" ($args.wrapCols | default "") }}
     {{ $input = $input | $args.page.RenderString }}
     {{ $store.Set "hinodeTableIsDataTable" $outer }}
     {{ $store.Set "hinodeTableCaption" $outerCaption }}
+    {{ $store.Set "hinodeTableWrapCols" $outerWrapCols }}
 
     {{ $regex := `<table\s*class="(.+?)"` }}
     {{ $current := (index (index (findRESubmatch $regex $input) 0) 1) }}

--- a/layouts/_shortcodes/table.html
+++ b/layouts/_shortcodes/table.html
@@ -77,6 +77,7 @@
         "filter-responsive"      $args.filterResponsive
         "justify"                $args.justify
         "wrap"                   $args.wrap
+        "wrap-cols"              $args.wrapCols
         "wrapper"                $args.wrapper
         "caption"                $args.caption
         "caption-top"            $args.captionTop


### PR DESCRIPTION
## Summary

Adds `wrap-cols` to the `table` shortcode: a comma-separated column count per rendered row, so a record folds into groups and stacks as a card on small devices instead of dropping only its last column.

`2,4,1` across seven columns keeps `#` and Name on the lead row, folds four badges onto a row of their own, and gives the description the last.

Consumes gethinode/mod-simple-datatables#298, released in **v4.2.0** and bumped here.

## Why

`wrap` folds one column, which is not enough for a table with many columns. A seven-column catalog table still measured **487px against a 358px container** on a 390px viewport after its description was folded — the remaining columns are each narrow, but there are too many of them. Folding the badge columns as a group removes the horizontal scroll rather than reducing it: the same table now measures 342px in a 342px container.

## Both wrap paths

A plain table folds server-side in `render-table.html` with display utilities and no JavaScript; a data table folds in the browser, because simple-datatables owns that DOM. The group list reaches the render hook through the page store, the way the caption and the data-table flag already do.

`colspan` counts the lead group rather than every column. The folded headings are `display: none` and contribute no column, so spanning the full count reaches past the grid and the folded row's stripe and bottom border stop part way across the table.

## Striping

The stripe alternates per record, so a record of N rows has a period of 2N. `nth-of-type` accepts no custom property, so the rules are emitted per row count rather than parameterised, and only past the default two — which the existing `.table-wrap` selector already covers, so tables that carry no count class are untouched.

## Group layout

A folded group lays its values out in equal columns that drop to as many as fit. Four fixed columns across a 390px viewport are ~74px each, narrower than a label like "Warehouse" — and a rendered badge is wider than its bare text — so a fixed count breaks values mid-word. `auto-fit` lays four values out 2×2 on a phone and 4-across when there is room.

Values fill their track rather than being sized to content, so a column the author centred or right-aligned keeps that alignment after folding; left is simply what `text-align` already resolves to.

The layout wrapper sits inside the cell, never on it: a `display` of grid or flex on a `td` takes it out of the table formatting context and `colspan` stops applying with it.

## Validation

A group list is refused unless every entry is a positive integer and the total matches the column count. A list left stale when a column is added falls back to wrapping the last column only, rather than folding on stale boundaries and silently dropping or duplicating a column.

## Testing

Five fixtures in `exampleSite/content/en/table-demo.md`, driven in a browser against **released modules only** at 390px and 1440px:

| Fixture | Result |
|---|---|
| Three groups, data table | `table-wrap-3`, 3 rows/record, folded rows full width, 4 chips, no overflow |
| Three groups, plain table | identical — both paths agree |
| Stale list (`2,4` of 7), data table | falls back to `table-wrap`, 2 rows/record |
| Stale list, plain table | identical |
| Existing default wrap | unchanged, no row-count class |

At 1440px the three-group tables are unwrapped with all seven headers and seven cells per row, and sorting by Name still reorders correctly — the row model is never touched.

`pnpm lint` and `pnpm test:templates` pass.

## Follow-up

Docs for the new argument are ready in gethinode/mod-docs and will be raised once this ships in v3.23.0 — that PR's example passes `wrap-cols`, which an older theme would not recognise.
