### PR TITLE
fix(seo): derive og:locale and inLanguage per site language

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -253,7 +253,7 @@
 [schema]
     type = "Organization"
     name = "Hinode"
-    locale = "en-US"
+    # locale = "en-US" # defaults to the locale of the current site language
     # twitter = "https://twitter.com/gethinode"
     # linkedIn = ""
     github = "https://github.com/gethinode/hinode"
@@ -274,7 +274,7 @@
 
 [opengraph]
     images = ["logo.png"]
-    locale = "en_US"
+    # locale = "en_US" # defaults to the locale of the current site language
 
 [links]
     hinode = "https://gethinode.com"

--- a/exampleSite/config/_default/languages.toml
+++ b/exampleSite/config/_default/languages.toml
@@ -29,8 +29,6 @@ caption = "Je code et je tweet des mèmes de développeurs."
 languageName = "Nederlands"
 contentDir = "content/nl"
 weight = 3
-[nl.params.opengraph]
-locale = "nl_NL"
 [nl.params.head]
 tagline = "Een Hugo Theme"
 [nl.params.social]

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -202,7 +202,7 @@
 [schema]
     type = "Organization"
     name = "Hinode"
-    locale = "en-US"
+    # locale = "en-US" # defaults to the locale of the current site language
     # twitter = "https://twitter.com/gethinode"
     # linkedIn = ""
     github = "https://github.com/gethinode/hinode"
@@ -223,7 +223,7 @@
 
 [opengraph]
     images = ["logo.png"]
-    locale = "en_US"
+    # locale = "en_US" # defaults to the locale of the current site language
 
 [links]
     bs_badge_heading = "https://getbootstrap.com/docs/5.3/components/badge/#headings"

--- a/layouts/_partials/head/opengraph.html
+++ b/layouts/_partials/head/opengraph.html
@@ -1,5 +1,8 @@
 {{/* Copied from doks */}}
-<meta property="og:locale" content="{{ .Site.Params.opengraph.locale }}">
+{{- $locale := "" -}}
+{{- with .Site.Params.opengraph -}}{{- $locale = .locale -}}{{- end -}}
+{{- $locale = partial "utilities/GetLocale.html" (dict "locale" $locale) -}}
+<meta property="og:locale" content="{{ replace $locale "-" "_" }}">
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
 <meta property="og:title" content="{{ $.Scratch.Get "title" }}">
 <meta property="og:description" content="{{ $.Scratch.Get "description" }}">

--- a/layouts/_partials/head/structured-data.html
+++ b/layouts/_partials/head/structured-data.html
@@ -20,6 +20,10 @@
 
 {{ $alt := slice .Site.Params.schema.twitter .Site.Params.schema.linkedin .Site.Params.schema.github }}
 
+{{ $locale := "" -}}
+{{ with .Site.Params.schema }}{{ $locale = .locale }}{{ end -}}
+{{ $locale = replace (partial "utilities/GetLocale.html" (dict "locale" $locale)) "_" "-" -}}
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -104,7 +108,7 @@
       "primaryImageOfPage": {
         "@id": {{ print .Permalink "#/schema/image/2" }}
       },
-      "inLanguage": "{{ .Site.Params.schema.locale }}",
+      "inLanguage": "{{ $locale }}",
       "potentialAction": [{
         "@type": "ReadAction", "target": [{{ .Permalink }}]
       }]

--- a/layouts/_partials/utilities/GetLocale.html
+++ b/layouts/_partials/utilities/GetLocale.html
@@ -1,0 +1,75 @@
+{{- /*
+    Resolves the locale of the current site language as a BCP 47 language tag,
+    e.g. "nl-NL". Callers that need the Open Graph form replace the hyphen with
+    an underscore; both notations are accepted as input, so doing so is safe
+    regardless of how the locale was obtained.
+
+    Explicit configuration always wins: pass the relevant site parameter as
+    `locale` and it is returned unchanged. Without it the tag is derived from
+    the site's language, so a multilingual site reports the correct locale per
+    language instead of repeating a single site-wide value.
+
+    Derivation uppercases an existing region subtag ("pt-br" -> "pt-BR"). A
+    language that carries no region ("nl", "zh-Hans") falls back to its most
+    common region, either from the table below or, as a last resort, from the
+    language subtag itself ("nl" -> "nl-NL"). Configure the locale explicitly
+    where that guess is wrong.
+
+    @param {string} locale  Configured locale, returned as-is when set.
+    @param {string} lang    Language tag to derive from. Defaults to the current
+                            site language; pass another to resolve a translation.
+
+    @returns {string}
+*/ -}}
+
+{{- $regions := dict
+    "af" "ZA" "ar" "AR" "be" "BY" "bn" "BD" "bs" "BA" "ca" "ES" "cs" "CZ"
+    "cy" "GB" "da" "DK" "el" "GR" "en" "US" "et" "EE" "eu" "ES" "fa" "IR"
+    "ga" "IE" "gl" "ES" "he" "IL" "hi" "IN" "hy" "AM" "ja" "JP" "ka" "GE"
+    "kk" "KZ" "ko" "KR" "ms" "MY" "nb" "NO" "nn" "NO" "sq" "AL" "sr" "RS"
+    "sv" "SE" "sw" "KE" "uk" "UA" "ur" "PK" "vi" "VN" "zh" "CN"
+    "zh-hans" "CN" "zh-hant" "TW"
+-}}
+
+{{- $locale := .locale -}}
+
+{{- if not $locale -}}
+    {{- $tag := lower (or .lang site.Language.Lang) -}}
+
+    {{- /* Hugo renamed `languageCode` to `locale` in v0.158.0; mirror rss.xml and read
+           whichever one the running version supports. */ -}}
+    {{- $code := "" -}}
+    {{- if le (hugo.Version.Compare "0.158.0") 0 -}}
+        {{- $code = site.Language.Locale -}}
+    {{- else -}}
+        {{- $code = site.Language.LanguageCode -}}
+    {{- end -}}
+    {{- $code = lower (replace (or $code "") "_" "-") -}}
+
+    {{- /* That setting is site-wide unless a language overrides it, so "en-us" surfaces
+           on the Dutch site too. Only honour it when it refines the language it is read
+           for, otherwise every language reports the default one. */ -}}
+    {{- if and $code (eq (index (split $code "-") 0) (index (split $tag "-") 0)) -}}
+        {{- $tag = $code -}}
+    {{- end -}}
+
+    {{- $parts := split $tag "-" -}}
+    {{- $language := index $parts 0 -}}
+    {{- $region := "" -}}
+
+    {{- if gt (len $parts) 1 -}}
+        {{- range after 1 $parts -}}
+            {{- if and (not $region) (eq (len .) 2) -}}
+                {{- $region = upper . -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+
+    {{- if not $region -}}
+        {{- $region = or (index $regions $tag) (index $regions $language) (upper $language) -}}
+    {{- end -}}
+
+    {{- $locale = printf "%s-%s" $language $region -}}
+{{- end -}}
+
+{{- return $locale -}}

--- a/tests/templates/hugo.toml
+++ b/tests/templates/hugo.toml
@@ -1,5 +1,9 @@
 baseURL = 'https://example.org/'
 title = 'template tests'
+# Deliberately not 'en-us': utilities/GetLocale.html has to refine a matching language with
+# this setting and ignore it for every other one, and only a value differing from the region
+# it would otherwise guess for English tells those two branches apart.
+locale = 'en-gb'
 disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
 [params]
   [params.main]
@@ -36,6 +40,9 @@ disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
 [[module.mounts]]
   source = '../../layouts/_partials/utilities/GetIncludeTOC.html'
   target = 'layouts/_partials/utilities/GetIncludeTOC.html'
+[[module.mounts]]
+  source = '../../layouts/_partials/utilities/GetLocale.html'
+  target = 'layouts/_partials/utilities/GetLocale.html'
 
 # assets/section-title.html initializes its arguments through mod-utils (InitArgs and the
 # structure data it reads), so those come from the vendored module — `mod:vendor` populates

--- a/tests/templates/hugo.toml
+++ b/tests/templates/hugo.toml
@@ -2,8 +2,11 @@ baseURL = 'https://example.org/'
 title = 'template tests'
 # Deliberately not 'en-us': utilities/GetLocale.html has to refine a matching language with
 # this setting and ignore it for every other one, and only a value differing from the region
-# it would otherwise guess for English tells those two branches apart.
-locale = 'en-gb'
+# it would otherwise guess for English tells those two branches apart. Set through the
+# deprecated `languageCode` rather than its v0.158.0 replacement `locale`, so the assertions
+# still run at the advertised v0.146.0 floor — v0.164 maps the old key onto the new one, so
+# both ends of the supported range agree. Swap it when #2049 moves the floor.
+languageCode = 'en-gb'
 disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
 [params]
   [params.main]

--- a/tests/templates/layouts/index.html
+++ b/tests/templates/layouts/index.html
@@ -479,3 +479,39 @@ FAIL {{ .case }}
 {{- end }}
 
 SIDEBAR INDENT FAILURES: {{ $inFail }}
+
+{{- /*
+    Assertions for utilities/GetLocale.html.
+
+    The `lang` argument stands in for the language of the site being rendered, so a
+    single-language harness can still cover what a multilingual build does. This site
+    sets `locale = 'en-gb'`, which every case below is resolved against.
+*/ -}}
+
+{{- $localeCases := slice
+  (dict "case" "site locale refines the language it belongs to" "args" (dict "lang" "en") "want" "en-GB")
+  (dict "case" "site locale is ignored for another language" "args" (dict "lang" "nl") "want" "nl-NL")
+  (dict "case" "language without region falls back to its own subtag" "args" (dict "lang" "fr") "want" "fr-FR")
+  (dict "case" "language without region falls back to the table" "args" (dict "lang" "ja") "want" "ja-JP")
+  (dict "case" "existing region subtag is uppercased" "args" (dict "lang" "pt-br") "want" "pt-BR")
+  (dict "case" "script subtag resolves through the table" "args" (dict "lang" "zh-hans") "want" "zh-CN")
+  (dict "case" "input case is normalised" "args" (dict "lang" "NL") "want" "nl-NL")
+  (dict "case" "unknown language guesses its own subtag" "args" (dict "lang" "eo") "want" "eo-EO")
+  (dict "case" "configured locale wins over the language" "args" (dict "locale" "de_AT" "lang" "nl") "want" "de_AT")
+  (dict "case" "configured locale wins over the site locale" "args" (dict "locale" "en_US" "lang" "en") "want" "en_US")
+-}}
+{{- $localeFail := 0 -}}
+{{- range $localeCases -}}
+{{- $got := partial "utilities/GetLocale.html" .args -}}
+{{- if eq $got .want }}
+PASS {{ .case }}: {{ $got }}
+{{- else }}
+FAIL {{ .case }}
+     want={{ .want }}
+     got ={{ $got }}
+{{- $localeFail = add $localeFail 1 -}}
+{{- errorf "GetLocale mismatch: case=%q want=%q got=%q" .case .want $got -}}
+{{- end -}}
+{{- end }}
+
+GETLOCALE FAILURES: {{ $localeFail }}


### PR DESCRIPTION
## Problem

`og:locale` and the JSON-LD `inLanguage` each read a single site-wide parameter:

```go-html-template
<meta property="og:locale" content="{{ .Site.Params.opengraph.locale }}">
"inLanguage": "{{ .Site.Params.schema.locale }}",
```

Those parameters ship with `en_US` / `en-US`, so on a multilingual site **every** language reports the locale of whichever one the value was written for. A Dutch page renders `<html lang="nl">` next to `<meta property="og:locale" content="en_US">` — LinkedIn and Facebook take the Dutch share as US English.

Each language can override the parameter, and this repo's own example site did so for French and Dutch, so the mechanism was never broken — just silent when you forget. Nothing in the output looks wrong: the tag is present and well-formed, it only contradicts the `lang` attribute beside it. Found on a bilingual production site that had carried `en_US` on its Dutch tree since launch, inherited from the starter config.

## Change

Both call sites now resolve through a new `utilities/GetLocale.html`:

- a configured locale is returned **unchanged**, so existing per-language overrides keep working;
- otherwise a BCP 47 tag is derived from the site language — an existing region subtag is uppercased (`pt-br` → `pt-BR`), a language carrying none falls back to its most common region (`nl` → `nl-NL`, `ja` → `ja-JP`, `zh-Hans` → `zh-CN`);
- a site-wide `locale` still refines the language it belongs to (`en` + `locale = "en-gb"` → `en-GB`) but no longer speaks for the others. This one matters more than it looks: `languageCode`/`locale` is inherited by every language, so reading it naively reproduces the original bug through a different door.

`og:locale` converts the result to the underscore form it wants; both notations are accepted as input, so the conversion is safe either way.

The hardcoded defaults are commented out in `config/_default/params.toml` and the example site's copy, since a set value would shadow the derivation. Hugo's `languageCode` → `locale` rename in v0.158.0 is handled with the same version gate `rss.xml` already uses.

## Verification

`tests/templates` gains 10 assertions for `GetLocale.html`, covering both branches of the site-locale rule, region uppercasing, the script-subtag path, and override precedence. The harness pins a site locale of `en-gb` deliberately — with `en-us` the "refines" and "ignored" branches produce identical output and the test proves nothing.

Example site build, before → after:

| | before | after |
|---|---|---|
| `/en/` | `en_US` | `en_US` |
| `/fr/` | `fr_FR` (explicit) | `fr_FR` (explicit, kept to cover the override path) |
| `/nl/` | **`en_US`** | `nl_NL` |

`inLanguage` follows the same split (`en-US` / `fr-FR` / `nl-NL`); it was `en-US` on all three before. The root docs site is unchanged at `en_US`. `pnpm test` passes.

## Hugo v0.146.0 compatibility

Checked against the advertised floor with a real v0.146.0 extended binary, not by reading release notes — relevant to #2049, which tracks the deprecations this area is tangled up in.

The partial is clean at the floor. It uses only `hugo.Version.Compare`, `split`, `after`, `index`, `dict` and `return`, all long-standing, and the version gate keeps `site.Language.Locale` (v0.158.0) out of reach of older Hugo, exactly as `rss.xml` does. Building the example site with v0.146.0 emits the correct `en_US` / `fr_FR` / `nl_NL`. (That build then fails later in the PostCSS step, on an unrelated npm warning the older Hugo treats as fatal — the HTML is already rendered by then and the failure is present without this change.)

The **test harness** was not, and the first push had a genuine bug: it pinned the site locale through `locale`, which v0.158.0 introduced. At the floor that key is silently ignored, English falls back to the region the table guesses for it, and the "site locale refines its own language" case failed — a test failing on the version the theme claims to support, over a setting the theme itself does not require. Fixed in 143ad76 by setting the deprecated `languageCode` instead: honoured across the whole supported range, and v0.164 maps it onto `locale`, so both ends agree. It runs green on v0.146.0 and v0.164.0. It is one more instance of the batch in #2049 and should move to `locale` when the floor does.

Worth noting the underlying asymmetry: sites on Hugo < v0.158.0 can only express a site locale through `languageCode`, and sites on v0.164 that have not migrated still do. Both are handled, so the fix does not quietly require a newer Hugo than the theme advertises.

## Follow-ups (not in this PR)

- The `template` starter repo ships the same hardcoded `locale` values; sites scaffolded from it will keep overriding the derivation until those are dropped too.
- `og:locale:alternate` is still never emitted, so a social scraper has no way to learn a page has translations. Worth being precise about the scope: crawlers are already covered, since Hugo's embedded sitemap template emits complete reciprocal `xhtml:link rel="alternate" hreflang` annotations, and Google treats that as equivalent to the head-level element. Open Graph consumers read the page rather than the sitemap, which is why this one is not redundant with it. `GetLocale.html` takes a `lang` argument so a future pass can resolve translations without further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
