### PR TITLE
fix(navbar): keep the color-mode toggle working when a page is shown again

### DIFF
--- a/assets/js/critical/color.js
+++ b/assets/js/critical/color.js
@@ -68,7 +68,12 @@ if (params.darkMode) {
   }
 
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-    if (storedTheme !== 'light' || storedTheme !== 'dark') {
+    // Only an unset or 'auto' preference follows the system. The condition here
+    // used to test the stored value against 'light' and 'dark' with ||, which no
+    // single value can fail on both sides, so it was always true: switching the
+    // system appearance overrode an explicit choice and overwrote it in storage.
+    const stored = getLocalStorage('theme', 'auto', 'functional')
+    if (!stored || stored === 'auto') {
       setTheme(getPreferredTheme())
     }
   })

--- a/assets/js/critical/color.js
+++ b/assets/js/critical/color.js
@@ -13,9 +13,6 @@ import { getLocalStorage, setLocalStorage } from './_cookie.js'
 if (params.darkMode) {
   const supportedThemes = ['auto', 'dark', 'light']
 
-  // retrieves the currently stored theme from local storage
-  const storedTheme = getLocalStorage('theme', 'auto', 'functional')
-
   // retrieves the theme preferred by the client, defaults to light
   function getPreferredTheme () {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
@@ -23,6 +20,11 @@ if (params.darkMode) {
 
   // retrieves the current theme, either from local storage or client's preferences
   function getTheme () {
+    // Read on every call rather than once when the script runs. Storage is shared
+    // across the origin, so a theme chosen in another document leaves a value read
+    // at load time stale — and a document served from the back/forward cache runs
+    // no script again, so a stale capture is all it would ever have to work from.
+    const storedTheme = getLocalStorage('theme', 'auto', 'functional')
     if (storedTheme) {
       return storedTheme
     } else {
@@ -96,6 +98,17 @@ if (params.darkMode) {
   window.addEventListener('load', () => {
     // update the selectors when all elements are ready
     updateSelectors()
+  })
+
+  // A page served from the back/forward cache is shown again without re-parsing:
+  // no script re-runs and neither DOMContentLoaded nor load fires, so the theme
+  // applied when it was cached is still on the document however long it sat there.
+  // This is the only notification that it is back on screen, and therefore the only
+  // chance to pick up a theme chosen elsewhere in the meantime.
+  window.addEventListener('pageshow', event => {
+    if (event.persisted) {
+      setTheme(getTheme())
+    }
   })
 
   // initialize theme as soon as possible to reduce screen flickering

--- a/assets/js/critical/color.js
+++ b/assets/js/critical/color.js
@@ -56,8 +56,14 @@ if (params.darkMode) {
   }
 
   function updateSelectors () {
+    const light = document.documentElement.getAttribute('data-bs-theme') === 'light'
     document.querySelectorAll('.navbar-mode-selector').forEach(chk => {
-      chk.checked = (document.documentElement.getAttribute('data-bs-theme') === 'light')
+      chk.checked = light
+      // Mirrored onto the attribute as well: `checked` held only as a property is
+      // invisible to innerHTML serialization, so anything that snapshots the page
+      // and restores it later reinstates the switch in whatever position the raw
+      // markup declares, irrespective of the theme actually in effect.
+      chk.toggleAttribute('checked', light)
     })
   }
 
@@ -67,13 +73,19 @@ if (params.darkMode) {
     }
   })
 
-  window.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('.navbar-mode-selector').forEach(chk => {
-      chk.addEventListener('change', function () {
-        document.documentElement.setAttribute('data-bs-theme-animate', 'true')
-        toggleTheme()
-      })
-    })
+  // Delegated to the document rather than bound to each selector, because the
+  // document survives what the selectors do not. Any wholesale replacement of the
+  // page's contents — a client-side router restoring a cached body, for instance —
+  // substitutes fresh inputs carrying no listeners, and this script cannot rebind
+  // them: it ships in the critical bundle, a <head> script, so it is absent from
+  // the replaced markup and never runs a second time. A listener bound per element
+  // on DOMContentLoaded therefore dies with the elements it was bound to, leaving a
+  // toggle that looks intact and does nothing until the page is reloaded.
+  document.addEventListener('change', event => {
+    const selector = event.target.closest?.('.navbar-mode-selector')
+    if (!selector) return
+    document.documentElement.setAttribute('data-bs-theme-animate', 'true')
+    toggleTheme()
   })
 
   window.addEventListener('load', () => {


### PR DESCRIPTION
# Color mode: survive a page being shown again without re-running

Three independent defects in the color-mode script, each with its own commit. They were found together because they share a cause: the script does its work once, when it runs, and a page can be shown again without it ever running a second time.

## 1. The toggle dies when the page contents are replaced

The `change` handler was bound to each `.navbar-mode-selector` inside `DOMContentLoaded`. Anything that replaces the document's contents wholesale substitutes fresh inputs carrying no listeners, and this script cannot rebind them — it ships in the critical bundle, a `<head>` script, so it is outside the replaced markup and never runs again. The toggle then looks intact and does nothing until a reload.

Sites pairing Hinode with a client-side router hit this on ordinary Back/Forward. htmx restores a cached page by swapping `document.body`'s `innerHTML`, which is exactly this shape.

Fixed by delegating to `document`, which is never replaced. No dependency on any router.

`updateSelectors` also now mirrors the state onto the `checked` attribute. Held only as a property it is invisible to `innerHTML` serialization, so a restored snapshot brought the switch back in whatever position the raw markup declared, regardless of the active theme.

## 2. A cached page comes back with a stale theme

A page served from the back/forward cache is shown without being re-parsed: no script runs again, and neither `DOMContentLoaded` nor `load` fires. It therefore carried whatever theme was on the document when it was cached. Switch theme on one page, go Back, and you meet the old one — until you reload.

`pageshow` is the only notification such a page receives, so the theme is re-applied there.

This needed a second change to work at all. `getTheme` read storage once, into a module-scope `const`. Storage is shared across the origin, so that value is stale as soon as another document writes it — and a restored page never gets to capture it again. A `pageshow` handler on its own would have re-applied the very value that was out of date. The read now happens per call.

## 3. An explicit theme choice did not survive a system appearance change

```js
if (storedTheme !== 'light' || storedTheme !== 'dark') {
```

No single value can fail both sides, so this was always true. Every system appearance change re-applied the system theme over whatever the visitor had picked — and overwrote the stored preference, losing the choice rather than merely overriding its display. Only an unset or `auto` preference should track the system.

## Verification

No JS test harness exists here, so these were driven in real browsers rather than asserted.

Both restore paths were reproduced against a live Hinode-based site before any change, and confirmed fixed after:

- **htmx history restore** — the toggle was dead after Back and the switch position wrong; with the fix both are correct. Driven through a real `hx-push-url` entry, verified as htmx-managed via `history.state.htmx`.
- **Back/forward cache** — reproduced in **real Safari 26.5.2** over WebDriver, which attaches no debugger and so does not suppress the page cache. A marker surviving alongside `pageshow` `persisted: true` proves a genuine cache restore rather than a re-parse:

  ```text
  A instrumented:  { theme: 'light', stored: 'light', marker: 'ALIVE' }
  B switched dark: { theme: 'dark',  stored: 'dark'  }
  A after Back:    { theme: 'light', stored: 'dark', marker: 'ALIVE', log: [true] }
  ```

  With the fix, `A after Back` returns `{ theme: 'dark', stored: 'dark' }`.

  Worth recording for anyone testing this later: **no automated browser can exercise bfcache** — the attached automation protocol disables it in Chromium, Firefox and WebKit alike. A trivial control page reports `persisted: false` in all three, and launch-flag overrides do not help. Real Safari over WebDriver was the only way to see it.

A seven-case suite covering all three defects passes, and each behavior is mutation-checked — reverting any single piece of the fix fails exactly the assertion that should catch it, including the `pageshow` handler paired with the old parse-time read, which still fails.

`pnpm test` passes (eslint, stylelint, markdownlint, template renders).
