### PR TITLE
fix(navbar): emit typed zero for --navbar-offset so length calc() consumers stay valid

### DIFF
--- a/assets/scss/components/_navbar.scss
+++ b/assets/scss/components/_navbar.scss
@@ -317,9 +317,28 @@ $theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out,
     color: var(--#{$prefix}navbar-color);
 }
 
+// Coerce a unitless zero (numeric `0` or the string `"0"`) into a typed
+// `0rem`. `$navbar-offset`/`$navbar-offset-xs` normally arrive as typed
+// lengths (e.g. `6rem`) from `navigation.offset`/`offsetXS` in the site
+// config, but a config that supplies a bare `0` would otherwise interpolate
+// as a bare zero below — invalid wherever the resulting custom property is
+// later substituted into a length calc() (see `.toc-sidebar`'s
+// `calc(var(--navbar-offset) + 1rem)` and the `.app-shell-active` override
+// further down this file).
+@function navbar-offset-typed($value) {
+    @if $value == 0 or $value == "0" {
+        // stylelint-disable-next-line length-zero-no-unit -- the unit is the
+        // point: this return value feeds a custom property substituted into
+        // length calc()s, where a bare zero is invalid at computed-value time.
+        @return 0rem;
+    }
+
+    @return $value;
+}
+
 :root {
     --dropdown-horizontal-bg: var(--#{$prefix}light);
-    --navbar-offset: #{$navbar-offset-xs};
+    --navbar-offset: #{navbar-offset-typed($navbar-offset-xs)};
 }
 
 .navbar-container {
@@ -329,7 +348,7 @@ $theme-mode-transition: background-color .5s ease-in-out, color .5s ease-in-out,
 
 @include media-breakpoint-up(#{$navbar-size}) {
     :root {
-        --navbar-offset: #{$navbar-offset};
+        --navbar-offset: #{navbar-offset-typed($navbar-offset)};
     }
 
     .navbar-container {
@@ -525,8 +544,11 @@ body.navbar-open {
 
     // At md+ the sidebar is visible and the navbar is sticky inside its own
     // column, so the body doesn't need the legacy `--navbar-offset` spacer.
+    // The zero must carry a unit: consumers substitute this custom property
+    // into length calc()s (e.g. `.toc-sidebar`'s `calc(var(--navbar-offset) + 1rem)`),
+    // and a bare `0` makes those declarations invalid at computed-value time.
     .app-shell-active {
-        --navbar-offset: 0;
+        --navbar-offset: 0rem;
     }
 
     // Stick the navbar to the top of its column. The sticky positioning


### PR DESCRIPTION
## Summary

`.app-shell-active` set `--navbar-offset: 0` (bare unitless zero) at md+. Any consumer substituting it into a length-typed `calc()` — including Hinode's own `.toc-sidebar` rules (`top: calc(var(--navbar-offset) + 1rem)`, `max-height: calc(100vh - var(--navbar-offset))`) — produces `calc(0 + <length>)`, which fails calc type-checking and makes the declaration invalid at computed-value time: `top` computes to `auto` (sticky silently dies) and `max-height` to `none`. A `var()` fallback does not rescue IACVT.

Changes:

- `--navbar-offset: 0` → `0rem` on `.app-shell-active`, with the mechanism recorded in the adjacent comment.
- New `navbar-offset-typed` Sass guard at the two interpolated setters (`#{$navbar-offset-xs}` / `#{$navbar-offset}`), since a site configuring `navigation.offset = 0` reproduces the identical bug through that path.
- Sweep of other bare-zero custom properties: the two `--bs-btn-padding-*` zeros in `.btn-link` are never length-`calc()`-consumed and remain valid as direct padding values — left unchanged.

## Verification

- exampleSite rebuilt before/after: the only compiled-CSS diff is `0` → `0rem`.
- Playwright repro against the real compiled bundles in Chromium, Firefox, and WebKit — before: `top: auto`, `max-height: none` (IACVT) in all three; after: typed values (`top: 16px`, `max-height` viewport-tracking).
- Config-path hazard reproduced with `HUGO_PARAMS_NAVIGATION_OFFSET=0` and confirmed closed by the guard.
- `pnpm lint` and template tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)