### PR TITLE
fix(shortcodes): size the file fence to the file it wraps

### DIFF
--- a/layouts/_shortcodes/file.md
+++ b/layouts/_shortcodes/file.md
@@ -10,7 +10,18 @@
 {{- $extension := strings.TrimLeft "." (path.Ext $file) -}}
 {{- $lang := $args.lang | default $extension -}}
 {{- $content := readFile $file -}}
-{{- printf "```%s\n%s\n```" $lang (trim $content "\r\n") -}}
+{{- /* A fence must be longer than any fence the file itself contains, else the
+       file's own fence closes this block early. CommonMark ends a fenced block
+       at the first closing run at least as long as the opening one, so a file
+       holding a ```-fenced example emitted inside a ``` fence stops the block
+       mid-file: the rest of the file is then read as prose, and later fences
+       re-open and swallow the content after them. */ -}}
+{{- $fence := "```" -}}
+{{- range findRE "(?m)^[ \t]*`{3,}" $content -}}
+{{- $run := trim . " \t" -}}
+{{- if ge (len $run) (len $fence) -}}{{- $fence = printf "%s`" $run -}}{{- end -}}
+{{- end -}}
+{{- printf "%s%s\n%s\n%s" $fence $lang (trim $content "\r\n") $fence -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Summary

Fixes #2147.

The markdown variant of the `file` shortcode always opened a three-backtick fence:

```go-html-template
{{- printf "```%s\n%s\n```" $lang (trim $content "\r\n") -}}
```

CommonMark ends a fenced block at the first closing run **at least as long as** the opening one. So when the file being embedded contains its own ```-fenced example, the emitted block closes partway through the file: the remainder is read as prose, and any later fence in the file re-opens and swallows what follows it.

This only affects the `.md` output — the HTML variant renders such a file correctly, so the two outputs disagree and only the markdown one is wrong.

## Reproduce

A page with `{{< file file="./skeleton.md" lang="markdown" >}}` where `skeleton.md` is a documentation template that itself contains a ` ```text ` example. In the generated markdown the outer block ends at the inner example's closing fence rather than at the end of the file.

Fence structure before, for one such page:

```text
  43  ```markdown     <- opens
 124  ```text
 131  ```             <- closes here (wrong)
 176  ```             <- re-opens
```

after:

```text
  43  ````markdown    <- opens
 124  ```text
 131  ```             <- now just content
 176  ````            <- closes here (correct)
```

## Approach

Scan the content for its longest fence run and open with one backtick more. A file with no fences is unaffected and still gets three.

## Note

There is a second, independent bug behind the same symptom: `mod-llm`'s `safe-content.html` matches fenced blocks with a single ```` ```+ ```` pattern, so a nested fence also ends its protected region early and the exposed tail is stripped from the output. Verified that fixing this shortcode alone does not resolve that — gethinode/mod-llm#147 covers it.