### PR TITLE
fix: hide the redundant data-table search label

### DIFF
--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -64,7 +64,14 @@ const purgecss = purgeCSSPlugin({
       'search-input',
       // Bootstrap utilities used by SimpleDatatables
       'float-right',
-      'float-left'
+      'float-left',
+      // mod-simple-datatables hides the search input's label, which would otherwise repeat
+      // the input's own placeholder, by passing a `visually-hidden` span as the label text.
+      // That class therefore only ever appears inside the module's JavaScript, never in a
+      // layout, so hugo_stats.json cannot record it. Core layouts happen to emit it too, but
+      // only on pages that render a button, spinner or carousel - a site with none of those
+      // would purge the class and put the duplicated label back on screen.
+      'visually-hidden'
     ],
     // Classes with these patterns will be preserved along with their children
     deep: [

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gethinode/mod-leaflet/v3 v3.1.3 // indirect
 	github.com/gethinode/mod-lottie/v3 v3.0.4 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.4 // indirect
-	github.com/gethinode/mod-simple-datatables/v4 v4.2.0 // indirect
+	github.com/gethinode/mod-simple-datatables/v4 v4.2.1 // indirect
 	github.com/gethinode/mod-utils/v6 v6.11.0 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/gethinode/mod-simple-datatables/v4 v4.1.1 h1:Bidf8FA9SxBBb163D0yteTya
 github.com/gethinode/mod-simple-datatables/v4 v4.1.1/go.mod h1:irmXKx2jeppfpGRsCC91vN8dA4U2nQfy2eW8bajUeJo=
 github.com/gethinode/mod-simple-datatables/v4 v4.2.0 h1:n1GyPqVQ6o44awWIAiAwg/xZ6LYYQZuTQk6CuagboeI=
 github.com/gethinode/mod-simple-datatables/v4 v4.2.0/go.mod h1:bIYh9MBNdBe5vzSfmymqVzdVh+RSA7yPbMfnIayg8eo=
+github.com/gethinode/mod-simple-datatables/v4 v4.2.1 h1:Se1TIpqzOGcQVLZ2K8Ud7GuoEuVj/gk1zRqZ0jOR0UA=
+github.com/gethinode/mod-simple-datatables/v4 v4.2.1/go.mod h1:X9j8YEPhKWhcPCdylQHwfNkAqLH8L9878XcHQLyGEc8=
 github.com/gethinode/mod-utils/v6 v6.7.0 h1:DxqKUb13/6ydcntGIrUj1YD892VwarB8zGj+77CeUwM=
 github.com/gethinode/mod-utils/v6 v6.7.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/gethinode/mod-utils/v6 v6.8.0 h1:Rz/6DlPKVW0791jSsobxx4I4pKQ38H4JOEeOV+GeRzU=

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "mod:vendor": "node scripts/mod-vendor.cjs",
     "mod:vendor:force": "rimraf _vendor && hugo mod vendor",
     "test": "npm-run-all lint test:templates",
+    "pretest:templates": "pnpm mod:vendor",
     "test:templates": "hugo -s tests/templates --logLevel error",
     "env": "hugo env",
     "precheck": "npm version",


### PR DESCRIPTION
Adopts [mod-simple-datatables v4.2.1](https://github.com/gethinode/mod-simple-datatables/pull/300) and adds the purge guard it depends on. Three commits, one patch release.

## `fix(deps)` — adopt mod-simple-datatables v4.2.1

v4.2.0 pulled in a newer `simple-datatables` whose template wraps the search input in a label and renders `labels.searchLabel` above it. The module never set that label, so it fell through to the library's hard-coded English `"Search"` — a visible duplicate of the input's own `Search...` placeholder, untranslated on every locale. The same bump added `labels.sortHint`, equally left at its English default.

v4.2.1 hides the label with a `visually-hidden` span driven by i18n (the input is a *child* of the label, so hiding the element would hide the input) and localizes `sortHint`.

**This is what fixes demo.gethinode.com**, which is built from the exampleSite in production.

## `fix(styles)` — keep `visually-hidden` out of the purge

The class now appears only inside the module's JavaScript, never in a layout, so `hugo_stats.json` cannot record it and PurgeCSS cannot see it. Safelisted beside the other classes SimpleDatatables applies at runtime. `exampleSite/config/postcss.config.js` re-exports this config, so both are covered.

Worth being precise about the risk: this is **defensive, not load-bearing here**. Control builds of the exampleSite with and without the entry produce a byte-identical `main.min.d60305381e7ebfb….css`, because core button/spinner/carousel markup already puts the class in the stats. It matters for a consumer site that renders none of those. Landing it in the same release as the bump means the class is never shipped unguarded.

## `fix(test)` — vendor Hugo modules before the template tests

`pnpm test` fails on a tree that has never been vendored: `test:templates` resolves mod-utils partials through `_vendor`, so a fresh clone or worktree dies on `utilities/InitArgs.html not found`. CI never hit this because `build:cache` vendors first and only then calls `test:templates` — the gap is local, and the husky pre-commit hook runs straight into it.

Bound to `test:templates` rather than `test`, so a direct invocation is covered too. `mod:vendor` is the conditional wrapper, so it is a no-op once `_vendor` is current.

## Verification

Production build of the exampleSite (`pnpm build:example`) against the **published** v4.2.1, no module replacement — 0 errors:

- The `visually-hidden` span is present in the shipped, minified `simple-datatables.en.min.*.js`
- `.visually-hidden` survives in the purged `main.min.*.css`
- Rendered at `-e production`: the visible label is gone, the `Search...` placeholder is intact, and the search box now sits level with the per-page select
- Accessibility tree still reports the input as a named `searchbox` — the label continues to name it, it is just not painted
- Cold `pnpm test:templates` on a tree with `_vendor` deleted now vendors and passes; it failed before

## Follow-up

gethinode.com is triggered by this release: its `mod-update` PR bumps hinode and mod-simple-datatables (it pins the latter directly too), and carries the same safelist entry since the site keeps its own PostCSS config rather than inheriting the theme's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)