### PR TITLE
fix(card): decouple the horizontal card's button spacing from the section rhythm

### DIFF
--- a/layouts/_partials/assets/card.html
+++ b/layouts/_partials/assets/card.html
@@ -104,7 +104,6 @@
 {{- end -}}
 
 {{/* Initialize global variables */}}
-{{- $padding := partial "utilities/GetPadding.html" -}}
 {{- $cardReadMore := partial "utilities/GetThemeIcon.html" (dict "id" "cardReadMore" "default" "fas chevron-right") -}}
 {{- $cardLinkIcon := partial "utilities/GetThemeIcon.html" (dict "id" "cardLinkIcon" "default" "fas arrow-right") -}}
 
@@ -237,7 +236,7 @@
 
     {{/* Render horizontal card */}}
     <div class="card {{ $colorStyle }} {{ $args.class }}">
-        <div class="{{ if $thumbnail }}row-cols-2 row {{ end }} g-0 h-100{{ if $args.button }} pb-{{ $padding.y }}{{ end }}">
+        <div class="{{ if $thumbnail }}row-cols-2 row {{ end }} g-0 h-100">
             {{- if $thumbnail -}}
                 <div class="{{ $col1 }}">
                     {{ $fullHeight := "card-img-h100" }}
@@ -294,10 +293,10 @@
 
                         {{ if and $href $args.button }}
                             {{ $label := (or $args.buttonLabel $title) | default (T "readMore") }}
-                            {{ $buttonClass := "card-button mb-n4" }}
+                            {{ $buttonClass := "card-button" }}
                             {{ $buttonType := (or $args.linkType $args.buttonType) }}
-                            {{ if eq $buttonType "link" }}{{ $buttonClass = "card-button card-button-link mb-n4" }}{{ end }}
-                            <div class="d-flex align-items-end">
+                            {{ if eq $buttonType "link" }}{{ $buttonClass = "card-button card-button-link" }}{{ end }}
+                            <div class="d-flex align-items-end pt-{{ $args.padding }}">
                                 {{ partial "assets/button.html" (dict
                                     "page"        $args.page
                                     "title"       $label

--- a/layouts/_partials/assets/card.html
+++ b/layouts/_partials/assets/card.html
@@ -236,7 +236,7 @@
     {{ end }}
 
     {{/* Render horizontal card */}}
-    <div class="card {{ $colorStyle }}{{ $args.class }}">
+    <div class="card {{ $colorStyle }} {{ $args.class }}">
         <div class="{{ if $thumbnail }}row-cols-2 row {{ end }} g-0 h-100{{ if $args.button }} pb-{{ $padding.y }}{{ end }}">
             {{- if $thumbnail -}}
                 <div class="{{ $col1 }}">
@@ -369,7 +369,6 @@
                         "href"        $href
                         "outline"     true
                         "button-size" "sm"
-                        "class"       "card-button"
                         "class"       $buttonClass
                         "link-type"   $buttonType
                     )}}

--- a/layouts/_shortcodes/card.html
+++ b/layouts/_shortcodes/card.html
@@ -50,7 +50,7 @@
 {{- $linkType := or (partial "utilities/GetArgParent" (dict "page" . "arg" "link-type")) (partial "utilities/GetArgParent" (dict "page" . "arg" "buttonType")) -}}
 {{- $cols := partial "utilities/GetArgParent" (dict "page" . "arg" "cols") -}}
 {{- $scroll := partial "utilities/GetArgParent" (dict "page" . "arg" "scroll") -}}
-{{- $wrapper := "" -}}
+{{- $wrapper := .Get "wrapper" | default "" -}}
 
 {{/* Override arguments */}}
 {{- if $path }}
@@ -66,7 +66,7 @@
 {{ end }}
 
 {{ if $scroll }}
-    {{ $wrapper = printf "card-block-%d p-0" $cols }}
+    {{ $wrapper = trim (printf "card-block-%d p-0 %s" $cols $wrapper) " " }}
 {{ end }}
 
 {{/* Main code */}}

--- a/tests/templates/content/blog/card-wrapper.md
+++ b/tests/templates/content/blog/card-wrapper.md
@@ -1,0 +1,5 @@
+---
+title: Card Wrapper
+---
+
+{{< card title="Wrapped" href="/blog/toc-override/" wrapper="probe-wrapper" header-style="none" footer-style="none" >}}Body{{< /card >}}

--- a/tests/templates/hugo.toml
+++ b/tests/templates/hugo.toml
@@ -12,6 +12,12 @@ disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
   [params.main]
     titleCase = true
     titleCaseExceptions = ["npm", "pnpm"]
+    # Deliberately not the theme's own default of 4. The card assertions have to show that a
+    # card's internal spacing is no longer a function of the site's section rhythm, and only a
+    # value the card would otherwise have emitted - and that nothing else in the card's markup
+    # produces by coincidence - makes a reintroduction of the coupling visible as a `pb-5`.
+    [params.main.padding]
+      y = 5
   [params.navigation]
     toc = true
   [params.pages]
@@ -98,3 +104,36 @@ disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
 [[module.mounts]]
   source = '../../_vendor/github.com/FortAwesome/Font-Awesome/svgs'
   target = 'assets/svgs/fa'
+
+# assets/card.html is the element under test for the card assertions. It renders its own
+# button through assets/button.html and its icon column through assets/card-icon.html, and
+# the classes on both are what the assertions read, so neither is stubbed. No case sets a
+# thumbnail, so the image render hook is never reached and no image pipeline is mounted.
+[[module.mounts]]
+  source = '../../layouts/_partials/assets/card.html'
+  target = 'layouts/_partials/assets/card.html'
+[[module.mounts]]
+  source = '../../layouts/_partials/assets/button.html'
+  target = 'layouts/_partials/assets/button.html'
+[[module.mounts]]
+  source = '../../layouts/_partials/assets/card-icon.html'
+  target = 'layouts/_partials/assets/card-icon.html'
+[[module.mounts]]
+  source = '../../layouts/_partials/utilities/OmitEmpty.html'
+  target = 'layouts/_partials/utilities/OmitEmpty.html'
+[[module.mounts]]
+  source = '../../data/structures/card.yml'
+  target = 'data/structures/card.yml'
+[[module.mounts]]
+  source = '../../data/structures/card-icon.yml'
+  target = 'data/structures/card-icon.yml'
+[[module.mounts]]
+  source = '../../data/structures/button.yml'
+  target = 'data/structures/button.yml'
+
+# The card shortcode is mounted as well, because the argument passthrough it owns cannot be
+# reached through the partial: the assertions for it render a fixture page whose body calls
+# the shortcode, which is the only path on which the shortcode's own argument handling runs.
+[[module.mounts]]
+  source = '../../layouts/_shortcodes/card.html'
+  target = 'layouts/_shortcodes/card.html'

--- a/tests/templates/layouts/index.html
+++ b/tests/templates/layouts/index.html
@@ -515,3 +515,113 @@ FAIL {{ .case }}
 {{- end }}
 
 GETLOCALE FAILURES: {{ $localeFail }}
+
+{{- /*
+    Assertions for the button spacing in assets/card.html.
+
+    A card with a button used to reserve the space under it with `pb-{main.padding.y}` on the
+    row wrapper and then pull the button down into that reserve with a hardcoded `mb-n4`.
+    `main.padding.y` is the rhythm *between sections of a page*, so the geometry inside a
+    single card was a function of a setting that has nothing to do with cards: raising the
+    site's section spacing inflated every card that carried a button, and lowering it below 4
+    made the subtraction negative and hung the button out of the card. The card's own
+    `padding` argument, which is what the stacked branch has always used for this, had no say.
+
+    The harness sets `main.padding.y = 5` precisely so that a regression is legible. If the
+    coupling came back, the row wrapper would carry `pb-5` and the `spacer` column of every
+    horizontal case below would still read `pt-{padding}` — so the wrapper is asserted in full
+    rather than by absence, and the last column pins the negative margin that paired with it.
+
+    Each case renders the real partial and reduces it to four probes: the class list of the
+    `.card` element, of the row wrapper, of the column that spaces the button, and whether
+    `mb-n4` survives anywhere in the markup. A probe that matches nothing reads as "-", which
+    is how the stacked cases record that they have no row wrapper and the button-less case
+    records that it opens no spacing column at all.
+
+    The padding values are deliberately spread across the range. `pt-3` is the argument's
+    default and would also be produced by a card that ignored the argument and hardcoded the
+    old middle value, so on its own it proves nothing; 0 and 5 are the two ends that only a
+    card actually reading `padding` can reach, and 0 is the one the coupling made unreachable.
+*/ -}}
+{{- $cardFail := 0 -}}
+{{- $cardPage := site.GetPage "/blog/without-exact" -}}
+{{- $cardBase := dict
+      "page"         $cardPage
+      "title"        "Probe"
+      "href"         "/blog/toc-override/"
+      "button"       true
+      "button-label" "Go"
+      "header-style" "none"
+      "footer-style" "none"
+-}}
+{{- $cardProbes := slice `class="card[^"]*"` `class="[^"]*g-0 h-100[^"]*"` `class="[^"]*align-items-end[^"]*"` -}}
+{{- $cardCases := slice
+  (dict "case" "horizontal card spaces its button by the default padding"
+        "args" (dict "orientation" "horizontal")
+        "want" (slice "card" "g-0 h-100" "d-flex align-items-end pt-3" "-"))
+  (dict "case" "padding zero leaves no gap under the button"
+        "args" (dict "orientation" "horizontal" "padding" 0)
+        "want" (slice "card" "g-0 h-100" "d-flex align-items-end pt-0" "-"))
+  (dict "case" "padding five spaces the button by five"
+        "args" (dict "orientation" "horizontal" "padding" 5)
+        "want" (slice "card" "g-0 h-100" "d-flex align-items-end pt-5" "-"))
+  (dict "case" "horizontal-sm follows the same argument"
+        "args" (dict "orientation" "horizontal-sm" "padding" 2)
+        "want" (slice "card" "g-0 h-100" "d-flex align-items-end pt-2" "-"))
+  (dict "case" "colour and caller class stay separate tokens"
+        "args" (dict "orientation" "horizontal" "color" "light" "class" "pb-0")
+        "want" (slice "card bg-light text-bg-light pb-0" "g-0 h-100" "d-flex align-items-end pt-3" "-"))
+  (dict "case" "a horizontal card without a button opens no spacing column"
+        "args" (dict "orientation" "horizontal" "button" false)
+        "want" (slice "card" "g-0 h-100" "-" "-"))
+  (dict "case" "the stacked branch is unchanged"
+        "args" (dict "padding" 3)
+        "want" (slice "card text-start p-3" "-" "col d-flex align-items-end pt-3" "-"))
+-}}
+{{- range $cardCases -}}
+{{- $html := replaceRE `\s+` " " (partial "assets/card.html" (merge $cardBase .args)) -}}
+{{- $got := slice -}}
+{{- range $probe := $cardProbes -}}
+    {{- $match := findRE $probe $html 1 -}}
+    {{- if $match -}}
+        {{- $value := strings.TrimSuffix `"` (strings.TrimPrefix `class="` (index $match 0)) -}}
+        {{- $got = $got | append (trim $value " ") -}}
+    {{- else -}}
+        {{- $got = $got | append "-" -}}
+    {{- end -}}
+{{- end -}}
+{{- $got = $got | append (cond (strings.Contains $html "mb-n4") "mb-n4" "-") -}}
+{{- if eq (delimit $got "|") (delimit .want "|") }}
+PASS {{ .case }}
+{{- else }}
+FAIL {{ .case }}
+     want={{ delimit .want "|" }}
+     got ={{ delimit $got "|" }}
+{{- $cardFail = add $cardFail 1 -}}
+{{- errorf "card spacing mismatch: case=%q want=%q got=%q" .case (delimit .want "|") (delimit $got "|") -}}
+{{- end -}}
+{{- end }}
+
+CARD SPACING FAILURES: {{ $cardFail }}
+
+{{- /*
+    Assertion for the `wrapper` argument of the card shortcode.
+
+    `wrapper` is declared in the card structure, so it reaches authors and the CMS snippet
+    generator, but the shortcode initialised its own `$wrapper` to the empty string and only
+    ever assigned to it for scrolling cards - the author's value was dropped before the
+    partial saw it, while the card-group shortcode passed its identically-named argument
+    straight through. It has to be exercised through a rendered page, because the argument
+    handling under test belongs to the shortcode and a direct partial call bypasses it.
+*/ -}}
+{{- $wrapperGot := "-" -}}
+{{- $wrapperHtml := replaceRE `\s+` " " (site.GetPage "/blog/card-wrapper").Content -}}
+{{- with findRE `class="[^"]*probe-wrapper[^"]*"` $wrapperHtml 1 -}}
+    {{- $wrapperGot = trim (strings.TrimSuffix `"` (strings.TrimPrefix `class="` (index . 0))) " " -}}
+{{- end -}}
+{{- if eq $wrapperGot "probe-wrapper" }}
+PASS shortcode wrapper reaches the partial: "{{ $wrapperGot }}"
+{{- else }}
+FAIL shortcode wrapper reaches the partial: want="probe-wrapper" got="{{ $wrapperGot }}"
+{{- errorf "card shortcode wrapper mismatch: want=%q got=%q" "probe-wrapper" $wrapperGot -}}
+{{- end }}


### PR DESCRIPTION
## Problem

A card with a button reserved the space beneath it with `pb-{main.padding.y}` on the row wrapper, then pulled the button down into that reserve with a hardcoded `mb-n4`:

```html
<div class="card bg-light text-bg-lightpb-0">
  <div class="row-cols-2 row g-0 h-100 pb-5">
    …
      <a class="… card-button card-button-link mb-n4">
```

`main.padding.y` is the rhythm *between sections of a page*. Using it here made the geometry inside a single card a function of a setting that has nothing to do with cards.

`git log -L` on the line shows how it got there: the class arrived as a literal `pb-5` in `564a62e7` ("Add optional button to card"), hand-tuned against the button's negative margin. `fe0d3553` ("Make padding globally configurable") then swept that literal up with the genuine section-level paddings.

Three things follow.

**The gap tracks a setting that isn't about cards.** It comes out as `main.padding.y - 1.5rem`, so raising the section rhythm inflates every card that carries a button. Below 4 the subtraction goes negative and the button hangs out of the card — so values the padding validator accepts break the layout.

**No author can reach it.** `class` lands on the `.card` element and the padding sits on the row wrapper one level down, so no utility class overrides it. The card's own `padding` argument — cascading, documented, and already the control the stacked branch uses for exactly this job — had no say.

**`class` was destroyed anyway.** The horizontal branch interpolated the colour style and the caller's class with no separator, so a card setting both `color` and `class` emitted one joined token: `text-bg-lightpb-0`. Both classes are lost. The stacked branch has always had the space; only this one is affected.

Found on a client site whose section rhythm is 5, where every horizontal card with a button carried a band of white space the editor could not remove — `class="pb-0"` landed on the wrong element and was mangled on the way there.

## Change

Space the button with `pt-{padding}` and drop both the wrapper reserve and the negative margin. That makes the two branches agree, and puts the spacing under the argument that names it — `padding=0` now means no gap, as it reads.

Also in scope, both found while tracing the above:

- **`class` separator** on the horizontal `.card` element, plus a duplicated `"class"` key in the stacked branch's button call that Go's `dict` has always discarded.
- **`wrapper` passthrough** in the card shortcode. It is declared in the card structure, so it reaches authors and the CMS snippet generator, but the shortcode initialised its own `$wrapper` to `""` and only assigned to it for scrolling cards — the author's value never reached the partial. `card-group` passes its identically-named argument straight through, so the two have disagreed on an argument they share.

## Tests

No page in the theme's own content renders a horizontal card with a button, which is why this drifted unnoticed. `tests/templates` now covers the path: seven cases over the `.card` classes, the row wrapper, the button's spacing column and the negative margin, plus a fixture page for the shortcode argument.

The harness sets `main.padding.y = 5` deliberately — a value the card would otherwise have emitted — so a reintroduced coupling shows up as a `pb-5` the assertions name, rather than as a silent absence. Padding runs at 0, 2, 3 and 5: the default alone would also be satisfied by a card that hardcoded the old middle value, while the ends are only reachable by one that actually reads the argument.

Reverting both templates fails six of the cases and exits non-zero. On the fix, `hugo -s tests/templates` is green (79 PASS, 0 FAIL), and CI runs it — `test:templates` is part of `build-command`, so it executed on all six platform/node combinations.

## Compatibility

Patch. Cosmetic, and confined to where the button sits.

At the theme's default `padding.y = 4`, with the card's default `padding = 3`:

| | before | after |
|---|---|---|
| above the button | ~0 | `pt-3` → 1rem |
| below the button | `pb-4` + `p-3` − `mb-n4` → 1rem | `p-3` → 1rem |

So a stock site keeps the space under the button unchanged and gains the card's own padding above it, where the negative margin previously left none. Sites that raised `main.padding.y` above 4 lose the extra band it was adding; a card that wants it back can ask with a larger `padding`. Sites below 4 stop having the button hang out of the card.

Sites that had worked around the mangled `class` by relying on the joined token will see the colour utility apply correctly again.
