### PR TITLE
fix(card): let the shortcode's padding argument express zero

### DIFF
--- a/layouts/_shortcodes/card.html
+++ b/layouts/_shortcodes/card.html
@@ -37,7 +37,18 @@
 {{- $subtle := partial "utilities/GetArgParent" (dict "page" . "arg" "subtle") -}}
 {{- $loading := .Get "loading" -}}
 {{- $orientation := partial "utilities/GetArgParent" (dict "page" . "arg" "orientation") -}}
-{{- $padding := partial "utilities/GetArgParent" (dict "page" . "arg" "padding") | default 3 -}}
+{{- /* Not GetArgParent: padding is an int whose 0 is a real value, and both that helper
+       (which reads the argument under `with`) and a trailing `| default` treat falsy as
+       absent, so `padding=0` silently resolved to the default. InitArgs already tells an
+       explicit 0 apart from an unset argument and applies the structure default, so
+       own-value-or-default comes from there; only the parent cascade is left to apply by
+       hand, and only when this card sets nothing itself. */ -}}
+{{- $padding := $args.padding -}}
+{{- if not (and .IsNamedParams (isset .Params "padding")) -}}
+    {{- with .Parent -}}
+        {{- if and .IsNamedParams (isset .Params "padding") }}{{ $padding = .Get "padding" }}{{ end -}}
+    {{- end -}}
+{{- end -}}
 {{- $ratio := partial "utilities/GetArgParent" (dict "page" . "arg" "ratio") -}}
 {{- $portrait := partial "utilities/GetArgParent" (dict "page" . "arg" "portrait") -}}
 {{- $page := .Page -}}

--- a/tests/templates/content/blog/card-padding.md
+++ b/tests/templates/content/blog/card-padding.md
@@ -1,0 +1,19 @@
+---
+title: Card Padding
+---
+
+<!-- padding=0: an explicit zero, the value the argument's own default hides -->
+{{< card title="Zero" href="/blog/toc-override/" padding=0 button=true button-label="Go" header-style="none" footer-style="none" >}}Body{{< /card >}}
+
+<!-- padding=5: an explicit non-default, to show the argument is read at all -->
+{{< card title="Five" href="/blog/toc-override/" padding=5 button=true button-label="Go" header-style="none" footer-style="none" >}}Body{{< /card >}}
+
+<!-- no padding: the structure default (3) applies -->
+{{< card title="Absent" href="/blog/toc-override/" button=true button-label="Go" header-style="none" footer-style="none" >}}Body{{< /card >}}
+
+<!-- cascade: the group's padding reaches a card that sets none, and a card
+     that sets an explicit zero still wins over the group's value -->
+{{< card-group padding=5 >}}
+{{< card title="Inherits" href="/blog/toc-override/" button=true button-label="Go" header-style="none" footer-style="none" >}}Body{{< /card >}}
+{{< card title="Overrides" href="/blog/toc-override/" padding=0 button=true button-label="Go" header-style="none" footer-style="none" >}}Body{{< /card >}}
+{{< /card-group >}}

--- a/tests/templates/hugo.toml
+++ b/tests/templates/hugo.toml
@@ -137,3 +137,23 @@ disableKinds = ['taxonomy', 'term', 'RSS', 'sitemap', 'robotsTXT', '404']
 [[module.mounts]]
   source = '../../layouts/_shortcodes/card.html'
   target = 'layouts/_shortcodes/card.html'
+
+# The padding cascade cannot be reached through a bare card: it is the card-group
+# shortcode that a nested card reads its parent value from, so the group and the
+# partial behind it are mounted too. The group renders a "more" link through
+# assets/button.html (already mounted) and, when paginated, assets/pagination.html.
+[[module.mounts]]
+  source = '../../layouts/_shortcodes/card-group.html'
+  target = 'layouts/_shortcodes/card-group.html'
+[[module.mounts]]
+  source = '../../layouts/_partials/assets/card-group.html'
+  target = 'layouts/_partials/assets/card-group.html'
+[[module.mounts]]
+  source = '../../layouts/_partials/assets/pagination.html'
+  target = 'layouts/_partials/assets/pagination.html'
+[[module.mounts]]
+  source = '../../data/structures/card-group.yml'
+  target = 'data/structures/card-group.yml'
+[[module.mounts]]
+  source = '../../data/structures/pagination.yml'
+  target = 'data/structures/pagination.yml'

--- a/tests/templates/layouts/index.html
+++ b/tests/templates/layouts/index.html
@@ -625,3 +625,49 @@ PASS shortcode wrapper reaches the partial: "{{ $wrapperGot }}"
 FAIL shortcode wrapper reaches the partial: want="probe-wrapper" got="{{ $wrapperGot }}"
 {{- errorf "card shortcode wrapper mismatch: want=%q got=%q" "probe-wrapper" $wrapperGot -}}
 {{- end }}
+
+{{- /*
+    Assertions for the card shortcode's `padding` argument.
+
+    The argument is an integer whose zero is a real value - "no padding" - but the
+    shortcode resolved it through two layers that each treat falsy as absent, so an
+    author writing `padding=0` silently got the default instead. `utilities/GetArgParent`
+    reads the value under `with`, which skips zero and returns the empty string; the
+    shortcode then applied `| default 3`, which skips zero again. Nothing warned: the
+    card simply rendered at padding 3.
+
+    That was invisible until the button spacing started reading the argument, because
+    the value's only other job is the card body's own `p-N`. It is `pt-N` on the button
+    column that these cases read, since that is now what an author changes `padding` to
+    control.
+
+    The cases pin all four resolutions the argument has. Zero is the regression. Five
+    proves the argument is read at all rather than the default coincidentally matching.
+    Absent proves the structure default still applies. The last two run inside a
+    card-group, where `padding` cascades: a card that sets nothing must take the
+    group's value, and a card that sets an explicit zero must still beat it - the same
+    falsy-is-absent trap, one level up.
+*/ -}}
+{{- $padFail := 0 -}}
+{{- $padHtml := replaceRE `\s+` " " (site.GetPage "/blog/card-padding").Content -}}
+{{- $padGot := slice -}}
+{{- range findRE `class="[^"]*align-items-end[^"]*"` $padHtml -}}
+    {{- $padGot = $padGot | append (index (findRE `pt-\d+` . 1) 0 | default "(none)") -}}
+{{- end -}}
+{{- $padWant := slice "pt-0" "pt-5" "pt-3" "pt-5" "pt-0" -}}
+{{- $padCases := slice "explicit zero" "explicit five" "absent takes the default" "inherits the group" "zero beats the group" -}}
+{{- range $i, $case := $padCases -}}
+{{- $got := index $padGot $i | default "(missing)" -}}
+{{- $want := index $padWant $i -}}
+{{- if eq $got $want }}
+PASS card padding: {{ $case }} -> {{ $got }}
+{{- else }}
+FAIL card padding: {{ $case }}
+     want={{ $want }}
+     got ={{ $got }}
+{{- $padFail = add $padFail 1 -}}
+{{- errorf "card padding mismatch: case=%q want=%q got=%q" $case $want $got -}}
+{{- end -}}
+{{- end }}
+
+CARD PADDING FAILURES: {{ $padFail }}


### PR DESCRIPTION
## Problem

`padding` is an integer whose `0` is a real value — "no padding" — but the card shortcode resolved it through two layers that each read falsy as absent:

```go
{{- $padding := partial "utilities/GetArgParent" (dict "page" . "arg" "padding") | default 3 -}}
```

`GetArgParent` takes the argument under `with`, which skips `0` and returns the empty string. The trailing `| default 3` then skips it again. An author writing `padding=0` got `3`, and nothing was logged.

It stayed invisible while the argument's only job was the card body's own `p-N`, where the difference reads as a styling choice rather than an ignored instruction. It stopped being invisible in #2150, which made `padding` the control for the horizontal card's button spacing: `padding=0` is now how you ask for a button with no gap above it, and it was the one value the argument could not carry.

Found on a client site — the same card that motivated #2150 sets `padding=0` and still rendered `pt-3`.

## Change

`InitArgs` already tells an explicit `0` apart from an unset argument and applies the structure's `default: 3`, so own-value-or-default now comes from `$args.padding`. Only the parent cascade is applied by hand, and only when the card sets nothing itself — which keeps a group's `padding` reaching its cards while letting a card's explicit `0` win over it, the same trap one level up.

This also starts paying off the `TODO: use initargs instead of GetArgParent` sitting at the top of that argument block.

## Tests

Five resolutions pinned in `tests/templates`, driven through a fixture page because the bug lives in the shortcode's own argument handling and a direct partial call bypasses it:

| case | want |
|---|---|
| explicit zero | `pt-0` |
| explicit five | `pt-5` |
| absent → structure default | `pt-3` |
| inherits the group's padding | `pt-5` |
| explicit zero beats the group | `pt-0` |

Against the unfixed shortcode, exactly the two zero cases fail and the build exits non-zero; the other three already passed, which is what scopes this to zero rather than to cascade or defaults generally. `five` is there so a card that ignored the argument entirely could not pass by coincidence with the default.

The cascade cases need the group a nested card reads its parent from, so `card-group` and `pagination` are mounted alongside. Locally: 84 PASS / 0 FAIL, exampleSite builds, all three linters clean.

## Scope note

The falsy-is-absent behaviour in `utilities/GetArgParent` (mod-utils) is **not** fixed here. It affects any cascading argument whose meaningful value is falsy — an explicit `false` on a boolean whose default is truthy has the same problem — but changing it would alter argument resolution for every shortcode that calls the helper. That deserves its own change with its own blast-radius review rather than riding along with this one.
