### PR TITLE
fix(image): name the page a missing image was referenced from

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -116,6 +116,7 @@
     showSCSS = false
     purgeHTMLComments = false
     includeSVGOrigin = true
+    failOnMissingImage = false
 # toml-docs-end debugging
 
 # toml-docs-start docs

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gethinode/mod-lottie/v3 v3.0.4 // indirect
 	github.com/gethinode/mod-mermaid/v5 v5.0.4 // indirect
 	github.com/gethinode/mod-simple-datatables/v4 v4.2.1 // indirect
-	github.com/gethinode/mod-utils/v6 v6.11.0 // indirect
+	github.com/gethinode/mod-utils/v6 v6.12.0 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 	github.com/twbs/bootstrap v5.3.8+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/gethinode/mod-utils/v6 v6.9.0 h1:+7RsNAfYCaM3rAzwrkTC6Ui3vcpGYWj1Ek1C
 github.com/gethinode/mod-utils/v6 v6.9.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/gethinode/mod-utils/v6 v6.11.0 h1:q1nQwf/oDVZMP/K9dkM8GQC2OdfljLL6sH3b+eHpfyw=
 github.com/gethinode/mod-utils/v6 v6.11.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
+github.com/gethinode/mod-utils/v6 v6.12.0 h1:j8dnZOiEHAp3a4KmvkGkqWFe6fJkXcm3iQtyptRx1W8=
+github.com/gethinode/mod-utils/v6 v6.12.0/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 h1:QDKcU3q39lFGzdVwM6kgCGnW3ibbMfYIi0Rwl62iJpo=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0/go.mod h1:5GdMfPAXzbA2gXBqTjC6l27kioSYzHlqDMh0+wyx7sU=
 github.com/twbs/bootstrap v5.3.8+incompatible h1:eK1fsXP7R/FWFt+sSNmmvUH9usPocf240nWVw7Dh02o=

--- a/layouts/_partials/assets/helpers/image-dimension.html
+++ b/layouts/_partials/assets/helpers/image-dimension.html
@@ -19,6 +19,17 @@
     {{ $error = $args.err }}
 {{ end }}
 
+{{/* An unresolvable image is reported through LogMsg rather than a bare warnf,
+     so the message carries the page that caused it and a warning id. Without
+     the page there is nothing to act on: a site of any size reports a missing
+     file with no way to find the reference to it. Sites that would rather not
+     publish a dead <img> at all set params.debugging.failOnMissingImage, which
+     turns the warning into a build failure. It defaults to false, because
+     referencing an image supplied outside the build — a CDN path, an asset
+     added at deploy time — is legitimate and must keep working. */}}
+{{- $strict := site.Params.debugging.failOnMissingImage | default false -}}
+{{- $logFile := (or $args.page page).File -}}
+
 {{/* Initialize local arguments */}}
 {{- $src := $args.src -}}
 {{- $height := or $args.imageHeight $args.height -}}
@@ -76,7 +87,13 @@
         {{- $targetURL := strings.TrimPrefix $u.Path $src -}}
         {{- $targetURL = strings.TrimPrefix "/static" $src -}}
         {{- if not (fileExists (path.Join "/static" $targetURL)) -}}
-            {{ warnf "Cannot find vector image resource: %q" $src -}}
+            {{ partial (cond $strict "utilities/LogErr.html" "utilities/LogWarn.html") (dict
+                "partial" "assets/helpers/image-dimension.html"
+                "warnid"  "warn-missing-image"
+                "msg"     "Cannot find vector image resource"
+                "details" (slice (printf "src: %q" $src) "searched: assets and static")
+                "file"    $logFile
+            )}}
         {{ else }}
             {{ $width := string (partial "utilities/GetWidth.html" (dict "path" $targetURL "height" 500)) }}
             {{ if $width }}
@@ -88,7 +105,17 @@
     {{ else if eq (string $res.MediaType) "image/svg+xml" }}
         {{ $data = $res.Content }}
     {{ else }}
-        {{ warnf "Unsupported media type '%s': %q" (string $res.MediaType) $src -}}
+        {{/* The file resolves, so this is a content error rather than a missing
+             asset — reported, but never escalated by failOnMissingImage. Shares
+             the warning id GetImage already uses for the same condition, so one
+             ignoreLogs entry covers both. */}}
+        {{ partial "utilities/LogWarn.html" (dict
+            "partial" "assets/helpers/image-dimension.html"
+            "warnid"  "warn-unsupported-image"
+            "msg"     (printf "Unsupported media type %q" (string $res.MediaType))
+            "details" (slice (printf "src: %q" $src))
+            "file"    $logFile
+        )}}
     {{ end }}
 {{ else if and $args.ratio (ne $args.ratio "auto") }}
     {{ $transform = "fill" }}


### PR DESCRIPTION
A missing vector image was reported with a bare `warnf` carrying only the src:

```text
WARN  Cannot find vector image resource: "/img/foo.svg"
```

On a site of any size that is not actionable — the log says a file is missing and **nothing says which page referenced it**, so finding the offending shortcode means grepping content by hand. It also has no warning id, so it cannot be suppressed with `ignoreLogs` the way every other Hinode warning can.

Both diagnostics now route through `LogMsg`, exactly as the invalid-arguments case a few lines above already does:

```text
WARN  partial [assets/helpers/image-dimension.html] - Cannot find vector image resource: my-page.md
	src: "/img/foo.svg"
	searched: assets and static
You can suppress this warning by adding the following to your project configuration:
ignoreLogs = [`warn-missing-image`]
```

### `params.debugging.failOnMissingImage`

New, defaulting to **false** — no existing site changes behavior. Referencing an image supplied outside the build (a CDN path, a deploy-time asset) is legitimate, so making this fatal by default would break working sites on upgrade.

gethinode/mod-utils#367 reads the same flag for raster images, so the setting means one thing across both repos. That PR should land and release first; the vector half of this one works independently of it.

### Scope notes

- **The unsupported-media-type case reuses `GetImage`'s existing `warn-unsupported-image` id** rather than inventing a second one, so a single `ignoreLogs` entry covers both. It is never escalated by `failOnMissingImage`: the file resolves, so it is a content error, not a missing asset.
- **Raster images already had page context** via `GetImage` — I initially added a second report for them and removed it after the build showed my branch never fired. This PR does not touch that path.

### Verification

exampleSite, with a probe page carrying a missing plain SVG, a missing `mode="true"` pair, and a missing raster:

| | before | after |
|---|---|---|
| diagnostic | `WARN Cannot find vector image resource: "<src>"` | names the page, the src, and the id |
| suppressible | no id | `ignoreLogs = [`warn-missing-image`]` |
| `mode="true"` pair | — | reports **both** expanded filenames, not one |
| `failOnMissingImage` set | n/a | `ERROR` ×4, exit **1** |
| `failOnMissingImage` unset | exit 0 | exit **0**, warnings only |

The mode-pair result is worth calling out: both `-light` and `-dark` are reported, so no extra call site is needed in the expansion path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)