### PR TITLE
fix(language-selector): keep the query string and hash through redirects

### DIFF
--- a/assets/js/critical/languageSelector.js
+++ b/assets/js/critical/languageSelector.js
@@ -18,17 +18,25 @@ if (params.languageSelector) {
     setLocalStorage('selectedLanguage', language, 'functional')
   }
 
+  // The query string and hash are payload, not identity: they never take part in
+  // deciding whether to redirect, and they ride along when one happens. Dropping
+  // them silently discards campaign parameters (utm_*, gclid, fbclid, ...) before
+  // an analytics tag can read them, and breaks anchor deep links.
+  function keepParams () {
+    return window.location.search + window.location.hash
+  }
+
   // Function to apply the selected language to the website
   function applyLanguage (language, href) {
     if (document.documentElement.lang !== language) {
       if (href) {
         if (window.location.pathname !== href) {
-          window.location.href = href
+          window.location.href = href + keepParams()
         }
       } else {
         const target = folder + language + '/'
-        if (window.location.href !== target) {
-          window.location.href = target
+        if (window.location.pathname !== target) {
+          window.location.href = target + keepParams()
         }
       }
     }
@@ -54,8 +62,19 @@ if (params.languageSelector) {
       alias = link.getAttribute('href')
     }
 
-    if ((alias !== '') && (window.location.href !== alias)) {
-      window.location.href = alias
+    // Only the location itself decides whether this page is already canonical;
+    // comparing the full href made any query string or hash look like a mismatch
+    // and bounced the visitor to the bare canonical URL. Cf. static/js/alias.js,
+    // which this script replaces when the language selector is enabled.
+    let onCanonical = true
+    if (alias !== '') {
+      const canonical = new URL(alias, window.location.href)
+      onCanonical = canonical.origin === window.location.origin &&
+        canonical.pathname === window.location.pathname
+    }
+
+    if (!onCanonical) {
+      window.location.href = alias + keepParams()
     } else if (languageItems.length > 0) {
       // Redirect if the stored language differs from the active language
       if ((storedLanguage) && (document.documentElement.lang !== storedLanguage)) {


### PR DESCRIPTION
## Problem

The canonical guard in `assets/js/critical/languageSelector.js` compares the **full** `window.location.href` against the `<link rel="canonical">` href and hard-navigates on any difference:

```js
if ((alias !== '') && (window.location.href !== alias)) {
  window.location.href = alias
}
```

The canonical never carries a query string, so any URL that does looks like a mismatch. The visitor is bounced to the bare canonical URL and the parameters are gone — `utm_source`, `utm_medium`, `utm_campaign`, plus `gclid`, `fbclid`, `msclkid`, `hsCtaTracking`. Anchor deep links (`#section`) are dropped the same way.

This is not limited to alias pages. When `main.enableLanguageSelectionStorage` is true this script replaces `static/js/alias.js` and ships in the critical bundle on **every** page, so the redirect fires site-wide. The only URL that escapes is `?force=true`, via the early return above.

`static/js/alias.js` — the redirect this script stands in for — already gets it right:

```js
const params = window.location.search + window.location.hash
window.location = alias + params
```

Reported by a marketing team whose campaign links lost their UTM parameters before GA4 could record the attribution.

## Fix

- Decide on the location alone: compare `origin` + `pathname`, so a page that is already canonical never redirects. This strictly reduces redirects, so it cannot introduce a new one.
- When a redirect *is* warranted (a genuine alias page), carry `location.search + location.hash` to the target, matching `alias.js`.
- Apply the same to `applyLanguage`, which dropped parameters when switching translations.
- Fix `applyLanguage`'s bare-folder branch, which compared a full href against a path (`window.location.href !== '/nl/'`) — a comparison that can never be equal, so the guard never suppressed anything.

## Behaviour

| case | before | after |
|---|---|---|
| plain canonical visit | stays put | stays put |
| UTM campaign link | **redirects, params lost** | stays put |
| `gclid` / ad click id | **redirects, params lost** | stays put |
| `#anchor` deep link | **redirects, anchor lost** | stays put |
| alias page | **redirects, params lost** | redirects, params kept |

Alias redirection is preserved — it just no longer discards the payload.

## Testing

`npm test` passes (eslint, stylelint, markdownlint, template tests).